### PR TITLE
QUICK-FIX ESLint ggrc's js_specs folder

### DIFF
--- a/src/ggrc/assets/js_specs/generated/ggrc_filter_query_parser_spec.js
+++ b/src/ggrc/assets/js_specs/generated/ggrc_filter_query_parser_spec.js
@@ -5,56 +5,54 @@
   Maintained By: miha@reciprocitylabs.com
   */
 
-describe('GGRC.query_parser', function() {
+/* eslint max-nested-callbacks: 0 */
 
+describe('GGRC.query_parser', function () {
   var values = {
-        'a': 'b',
-        'hello': 'world',
-        'n': '22',
-        '5words': 'These are just 5 words',
-        'bacon ipsum': 'Bacon ipsum dolor amet meatloaf pork loin fatback ball'+
-          'tip chicken frankfurter swine bresaola beef ribs ribeye shankle sho'+
-          'rt ribs drumstick leberkas sirloin. Turducken hamburger drumstick g'+
-          'round round ham biltong. Alcatra turkey brisket pancetta jowl bilto'+
-          'ng meatball, shank pork chop. Flank fatback capicola chuck chicken '+
-          'jerky venison meatball beef drumstick.'
-      },
-      all_keys = Object.keys(values),
-      parser_structure = {
-        parse: jasmine.any(Function),
-        join_queries: jasmine.any(Function),
-        generated: {
-          parse: jasmine.any(Function),
-          SyntaxError: jasmine.any(Function)
-        }
-      };
+    a: 'b',
+    hello: 'world',
+    n: '22',
+    '5words': 'These are just 5 words',
+    'bacon ipsum':
+      'Bacon ipsum dolor amet meatloaf pork loin fatback ball' +
+      'tip chicken frankfurter swine bresaola beef ribs ribeye shankle sho' +
+      'rt ribs drumstick leberkas sirloin. Turducken hamburger drumstick g' +
+      'round round ham biltong. Alcatra turkey brisket pancetta jowl bilto' +
+      'ng meatball, shank pork chop. Flank fatback capicola chuck chicken ' +
+      'jerky venison meatball beef drumstick.'
+  };
 
+  var all_keys = Object.keys(values);
 
-  it("should exist", function() {
+  var parser_structure = {
+    parse: jasmine.any(Function),
+    join_queries: jasmine.any(Function),
+    generated: {
+      parse: jasmine.any(Function),
+      SyntaxError: jasmine.any(Function)
+    }
+  };
+
+  it('should exist', function () {
     expect(GGRC.query_parser).toEqual(parser_structure);
   });
 
-
-  describe("parse", function() {
-
-    it("parses an empty query", function(){
-
+  describe('parse', function () {
+    it('parses an empty query', function () {
       var empty_result = {
         expression: {},
         keys: [],
         evaluate: jasmine.any(Function),
-        order_by : { keys : [ ], order : '', compare : null }
+        order_by: {keys: [], order: '', compare: null}
       };
 
-      expect(GGRC.query_parser.parse("")).toEqual(empty_result);
-      expect(GGRC.query_parser.parse(" ")).toEqual(empty_result);
-      expect(GGRC.query_parser.parse(" \t ")).toEqual(empty_result);
-      expect(GGRC.query_parser.parse("\t")).toEqual(empty_result);
+      expect(GGRC.query_parser.parse('')).toEqual(empty_result);
+      expect(GGRC.query_parser.parse(' ')).toEqual(empty_result);
+      expect(GGRC.query_parser.parse(' \t ')).toEqual(empty_result);
+      expect(GGRC.query_parser.parse('\t')).toEqual(empty_result);
     });
 
-
-    it("parses text search queries", function(){
-
+    it('parses text search queries', function () {
       var text_search_queries = [
         '!~a',
         '!~word',
@@ -65,25 +63,24 @@ describe('GGRC.query_parser', function() {
         '!~7531902 468'
       ];
 
-      can.each(text_search_queries, function(query_str){
-        var text = query_str.replace("!~","").trim()
+      can.each(text_search_queries, function (query_str) {
+        var text = query_str.replace('!~', '').trim();
+
         expect(GGRC.query_parser.parse(query_str)).toEqual({
-          expression: { 
-            text: text, 
-            op: {name: 'exclude_text_search'}, 
+          expression: {
+            text: text,
+            op: {name: 'exclude_text_search'},
             evaluate: jasmine.any(Function)
           },
-          order_by : { keys : [ ], order : '', compare : null },
+          order_by: {keys: [], order: '', compare: null},
           keys: [],
           evaluate: jasmine.any(Function)
         });
       });
     });
 
-
-    it("parses text search queries", function(){
-
-      var text_search_queries = [
+    it('parses text search queries', function () {
+      var textSearchQueries = [
         'a',
         'word',
         ' --this --is',
@@ -97,24 +94,23 @@ describe('GGRC.query_parser', function() {
         '~7531902 468'
       ];
 
-      can.each(text_search_queries, function(query_str){
-        var text = query_str.replace("~","").trim()
+      can.each(textSearchQueries, function (query_str) {
+        var text = query_str.replace('~', '').trim();
+
         expect(GGRC.query_parser.parse(query_str)).toEqual({
-          expression: { 
-            text: text, 
-            op: {name: 'text_search'}, 
+          expression: {
+            text: text,
+            op: {name: 'text_search'},
             evaluate: jasmine.any(Function)
           },
-          order_by : { keys : [ ], order : '', compare : null },
+          order_by: {keys: [], order: '', compare: null},
           keys: [],
           evaluate: jasmine.any(Function)
         });
       });
     });
 
-
-    it("parses \'=\' queries", function(){
-
+    it('parses \'=\' queries', function () {
       var simple_queries = [
         'a=b',
         'hello=world',
@@ -122,143 +118,140 @@ describe('GGRC.query_parser', function() {
         'but= not_all_spaces  '
       ];
 
-      can.each(simple_queries, function(query_str){
+      can.each(simple_queries, function (query_str) {
         var query = query_str.split('=');
         expect(GGRC.query_parser.parse(query_str)).toEqual({
           expression: {
             left: query[0].trim(),
-            op: { name: '=', evaluate: jasmine.any(Function) },
+            op: {name: '=', evaluate: jasmine.any(Function)},
             right: query[1].trim(),
             evaluate: jasmine.any(Function)
           },
-          order_by : { keys : [ ], order : '', compare : null },
+          order_by: {keys: [], order: '', compare: null},
           keys: [query[0].trim()],
           evaluate: jasmine.any(Function)
         });
       });
     });
 
-    it('parses \'~\' queries', function(){
+    it('parses \'~\' queries', function () {
+      expect(
+        GGRC.query_parser.parse('5words ~ just')
+      ).toEqual({
+        expression: {
+          left: '5words',
+          op: {name: '~', evaluate: jasmine.any(Function)},
+          right: 'just',
+          evaluate: jasmine.any(Function)
+        },
+        order_by: {keys: [], order: '', compare: null},
+        keys: ['5words'],
+        evaluate: jasmine.any(Function)
+      });
+    });
 
-      expect(GGRC.query_parser.parse('5words ~ just')).toEqual({
+    it('works with order by statement', function () {
+      expect(
+        GGRC.query_parser.parse(
+          '5words ~ just order by some,"name with spaces" desc')
+      ).toEqual({
+        expression: {
+          left: '5words',
+          op: {name: '~', evaluate: jasmine.any(Function)},
+          right: 'just',
+          evaluate: jasmine.any(Function)
+        },
+        order_by: {
+          keys: ['some', 'name with spaces'],
+          order: 'desc',
+          compare: jasmine.any(Function)
+        },
+        keys: ['5words'],
+        evaluate: jasmine.any(Function)
+      });
+    });
+
+    it('parses relevant queries', function () {
+      expect(GGRC.query_parser.parse('#SomeClass,1,2,3,4#'))
+        .toEqual({
           expression: {
-            left: '5words',
-            op: { name: '~', evaluate: jasmine.any(Function) },
-            right: 'just',
+            object_name: 'SomeClass',
+            op: {name: 'relevant'},
+            ids: ['1', '2', '3', '4'],
             evaluate: jasmine.any(Function)
           },
-          order_by : { keys : [ ], order : '', compare : null },
-          keys: ['5words'],
+          order_by: {keys: [], order: '', compare: null},
+          keys: [],
           evaluate: jasmine.any(Function)
         });
 
-    });
-
-    it('works with order by statement', function(){
-
-      expect(GGRC.query_parser
-          .parse('5words ~ just order by some,"name with spaces" desc'))
-          .toEqual({
-            expression: {
-              left: '5words',
-              op: { name: '~', evaluate: jasmine.any(Function) },
-              right: 'just',
-              evaluate: jasmine.any(Function)
-            },
-            order_by : {
-              keys : ['some', 'name with spaces' ],
-              order : 'desc',
-              compare : jasmine.any(Function)
-            },
-            keys: ['5words'],
-            evaluate: jasmine.any(Function)
-          });
-    });
-
-    it("parses relevant queries", function(){
-
-      expect(GGRC.query_parser.parse("#SomeClass,1,2,3,4#"))
-          .toEqual({
-            expression: {
+      expect(GGRC.query_parser.parse('#SomeClass,1,2,3,4# or #A,1# and #B,2#'))
+        .toEqual({
+          expression: {
+            left: {
               object_name: 'SomeClass',
-              op: {name: "relevant"},
-              ids: ["1","2","3","4"],
+              op: {name: 'relevant'},
+              ids: ['1', '2', '3', '4'],
               evaluate: jasmine.any(Function)
             },
-            order_by : { keys : [ ], order : '', compare : null },
-            keys: [],
-            evaluate: jasmine.any(Function)
-          });
-
-      expect(GGRC.query_parser.parse("#SomeClass,1,2,3,4# or #A,1# and #B,2#"))
-          .toEqual({
-            expression:{
-               left: {
-                object_name: 'SomeClass',
-                op: {name: "relevant"},
-                ids: ["1","2","3","4"],
+            op: {name: 'OR', evaluate: jasmine.any(Function)},
+            right: {
+              left: {
+                object_name: 'A',
+                op: {name: 'relevant'},
+                ids: ['1'],
                 evaluate: jasmine.any(Function)
               },
-              op: {name: "OR", evaluate: jasmine.any(Function)},
+              op: {name: 'AND', evaluate: jasmine.any(Function)},
               right: {
-                left: {
-                  object_name: "A",
-                  op: {name: "relevant"},
-                  ids: ["1"],
-                  evaluate: jasmine.any(Function)
-                },
-                op: {name: "AND", evaluate: jasmine.any(Function)},
-                right: {
-                  object_name: "B",
-                  op: {name: "relevant"},
-                  ids: ["2"],
-                  evaluate: jasmine.any(Function)
-                },
+                object_name: 'B',
+                op: {name: 'relevant'},
+                ids: ['2'],
                 evaluate: jasmine.any(Function)
               },
               evaluate: jasmine.any(Function)
             },
-            order_by : { keys : [ ], order : '', compare : null },
-            keys: [],
             evaluate: jasmine.any(Function)
-          });
+          },
+          order_by: {keys: [], order: '', compare: null},
+          keys: [],
+          evaluate: jasmine.any(Function)
+        });
 
-      expect(GGRC.query_parser.parse("#SomeClass,1,2,3,4# or #A,1#"))
-          .toEqual({
-            expression:{
-               left: {
-                object_name: 'SomeClass',
-                op: {name: "relevant"},
-                ids: ["1","2","3","4"],
-                evaluate: jasmine.any(Function)
-              },
-              op: {name: "OR", evaluate: jasmine.any(Function)},
-              right: {
-                object_name: "A",
-                op: {name: "relevant"},
-                ids: ["1"],
-                evaluate: jasmine.any(Function)
-              },
+      expect(GGRC.query_parser.parse('#SomeClass,1,2,3,4# or #A,1#'))
+        .toEqual({
+          expression: {
+            left: {
+              object_name: 'SomeClass',
+              op: {name: 'relevant'},
+              ids: ['1', '2', '3', '4'],
               evaluate: jasmine.any(Function)
             },
-            order_by : { keys : [ ], order : '', compare : null },
-            keys: [],
+            op: {name: 'OR', evaluate: jasmine.any(Function)},
+            right: {
+              object_name: 'A',
+              op: {name: 'relevant'},
+              ids: ['1'],
+              evaluate: jasmine.any(Function)
+            },
             evaluate: jasmine.any(Function)
-          });
+          },
+          order_by: {keys: [], order: '', compare: null},
+          keys: [],
+          evaluate: jasmine.any(Function)
+        });
     });
 
-    describe("evaluate", function(){
-
-      it("returns true on an empty query", function(){
-        expect(GGRC.query_parser.parse("").evaluate()).toEqual(true);
-        expect(GGRC.query_parser.parse(" ").evaluate()).toEqual(true);
-        expect(GGRC.query_parser.parse("\t").evaluate()).toEqual(true);
-        expect(GGRC.query_parser.parse("  \t  ").evaluate()).toEqual(true);
-        expect(GGRC.query_parser.parse("    \t").evaluate()).toEqual(true);
+    describe('evaluate', function () {
+      it('returns true on an empty query', function () {
+        expect(GGRC.query_parser.parse('').evaluate()).toEqual(true);
+        expect(GGRC.query_parser.parse(' ').evaluate()).toEqual(true);
+        expect(GGRC.query_parser.parse('\t').evaluate()).toEqual(true);
+        expect(GGRC.query_parser.parse('  \t  ').evaluate()).toEqual(true);
+        expect(GGRC.query_parser.parse('    \t').evaluate()).toEqual(true);
       });
 
-      it("works on simple queries", function(){
-
+      it('works on simple queries', function () {
         expect(GGRC.query_parser.parse('a=b')
             .evaluate(values)).toEqual(true);
         expect(GGRC.query_parser.parse('n = 22')
@@ -271,8 +264,7 @@ describe('GGRC.query_parser', function() {
             .evaluate(values)).toEqual(true);
       });
 
-      it("works on more comlpex queries", function(){
-
+      it('works on more comlpex queries', function () {
         expect(GGRC.query_parser.parse('a=b')
             .evaluate(values)).toEqual(true);
         expect(GGRC.query_parser.parse('(n = 22 or n = 5)')
@@ -290,7 +282,7 @@ describe('GGRC.query_parser', function() {
             .evaluate(values)).toEqual(true);
       });
 
-      it("does full text search", function(){
+      it('does full text search', function () {
         expect(GGRC.query_parser.parse('b')
             .evaluate(values, ['n'])).toEqual(false);
         expect(GGRC.query_parser.parse('b')
@@ -309,7 +301,7 @@ describe('GGRC.query_parser', function() {
             .evaluate(values, all_keys)).toEqual(false);
       });
 
-      it("does full text exclude search", function(){
+      it('does full text exclude search', function () {
         expect(GGRC.query_parser.parse('!~b')
             .evaluate(values, ['n'])).toEqual(true);
         expect(GGRC.query_parser.parse('!~b')
@@ -328,7 +320,7 @@ describe('GGRC.query_parser', function() {
             .evaluate(values, all_keys)).toEqual(true);
       });
 
-      it("evaluates expressions that end with a full text search", function(){
+      it('evaluates expressions that end with a full text search', function () {
         expect(GGRC.query_parser.parse('hello=worldoo or ~ bacon ipsum')
             .evaluate(values, all_keys)).toEqual(true);
         expect(GGRC.query_parser
@@ -343,19 +335,17 @@ describe('GGRC.query_parser', function() {
       });
     });
 
-    describe("join_queries", function(){
+    describe('join_queries', function () {
+      it('joins two queries with AND by default', function () {
+        var same_queries = [
+          ['a=b and c=d', 'a=b', 'c=d'],
+          ['(a=b) and (c=d)', 'a=b', 'c=d'],
+          ['(a=b or c=A) and (c=d)', 'a=b or c=A', 'c=d'],
+          ['(a=b or c=A) and (c=d)', '(a=b or c=A) and (c=d)', ''],
+          ['(a=b or c=A) and (c=d)', '', '(a=b or c=A) and (c=d)']
+        ];
 
-      it("joins two queries with AND by default", function(){
-
-        same_queries = [
-          ["a=b and c=d", "a=b", "c=d"],
-          ["(a=b) and (c=d)", "a=b", "c=d"],
-          ["(a=b or c=A) and (c=d)", "a=b or c=A", "c=d"],
-          ["(a=b or c=A) and (c=d)", "(a=b or c=A) and (c=d)", ""],
-          ["(a=b or c=A) and (c=d)", "", "(a=b or c=A) and (c=d)"],
-        ]
-
-        can.each(same_queries, function(queries){
+        can.each(same_queries, function (queries) {
           expect(
             JSON.stringify(GGRC.query_parser.parse(queries[0]))
           ).toEqual(
@@ -369,15 +359,14 @@ describe('GGRC.query_parser', function() {
         });
       });
 
-      it("joins two queries with OR", function(){
+      it('joins two queries with OR', function () {
+        var same_queries = [
+          ['a=b or c=d', 'a=b', 'c=d'],
+          ['(a=b) or (c=d)', 'a=b', 'c=d'],
+          ['(a=b and c=A) or (c=d)', 'a=b and c=A', 'c=d']
+        ];
 
-        same_queries = [
-          ["a=b or c=d", "a=b", "c=d"],
-          ["(a=b) or (c=d)", "a=b", "c=d"],
-          ["(a=b and c=A) or (c=d)", "a=b and c=A", "c=d"],
-        ]
-
-        can.each(same_queries, function(queries){
+        can.each(same_queries, function (queries) {
           expect(
             JSON.stringify(GGRC.query_parser.parse(queries[0]))
           ).toEqual(
@@ -385,23 +374,22 @@ describe('GGRC.query_parser', function() {
               GGRC.query_parser.join_queries(
                 GGRC.query_parser.parse(queries[1]),
                 GGRC.query_parser.parse(queries[2]),
-                "OR"
+                'OR'
               )
             )
           );
         });
       });
 
-      it("evaluates joined queries correctly", function(){
-
-        queries = [
-          ["(hello=worldoo or n=22 ) and ~ bacon ipsum", 
-            "(hello=worldoo or n=22 )", 
-            "  ~ bacon ipsum"], // should eval to true
-          ["hello=worldoo and ~ bacon ipsum", 
-            "hello=worldoo", 
-            "~ bacon ipsum"], // should eval to false
-        ]
+      it('evaluates joined queries correctly', function () {
+        var queries = [
+          ['(hello=worldoo or n=22 ) and ~ bacon ipsum',
+            '(hello=worldoo or n=22 )',
+            '  ~ bacon ipsum'], // should eval to true
+          ['hello=worldoo and ~ bacon ipsum',
+            'hello=worldoo',
+            '~ bacon ipsum'] // should eval to false
+        ];
 
         expect(
           GGRC.query_parser.parse(queries[0][0]).evaluate(values, all_keys)

--- a/src/ggrc/assets/js_specs/models/cacheable_spec.js
+++ b/src/ggrc/assets/js_specs/models/cacheable_spec.js
@@ -5,508 +5,590 @@
     Maintained By: brad@reciprocitylabs.com
 */
 
-describe("can.Model.Cacheable", function() {
+/* global failAll: false */
+/* eslint max-nested-callbacks: 0 */
 
-  beforeAll(function() {
-    can.Model.Mixin("dummyable");
-    spyOn(CMS.Models.Mixins.dummyable, "add_to");
+describe('can.Model.Cacheable', function () {
+  beforeAll(function () {
+    can.Model.Mixin('dummyable');
+    spyOn(CMS.Models.Mixins.dummyable, 'add_to');
 
-    can.Model.Cacheable.extend("CMS.Models.DummyModel", {
-      root_object: "dummy_model",
-      root_collection: "dummy_models",
-      // The string update key has to be here to make the update conflict tests work.
-      //  See can.Model.Cacheable.init for details on how the software
-      //  under test is broken. --BM
+    can.Model.Cacheable.extend('CMS.Models.DummyModel', {
+      root_object: 'dummy_model',
+      root_collection: 'dummy_models',
+      // The string update key has to be here to make the update conflict
+      // tests work. See can.Model.Cacheable.init for details on how the
+      // software under test is broken. --BM
       findOne: 'GET /api/dummy_models/{id}',
       findAll: 'GET /api/dummy_models/',
-      update: "PUT /api/dummy_models/{id}",
-      mixins: ["dummyable"],
-      attributes: { dummy_attribute: "dummy_convert" },
+      update: 'PUT /api/dummy_models/{id}',
+      mixins: ['dummyable'],
+      attributes: {dummy_attribute: 'dummy_convert'},
       is_custom_attributable: true
     }, {});
 
-    can.Model.Cacheable.extend("CMS.Models.DummyJoin", {
-      root_object: "dummy_join",
-      root_collection: "dummy_joins",
+    can.Model.Cacheable.extend('CMS.Models.DummyJoin', {
+      root_object: 'dummy_join',
+      root_collection: 'dummy_joins'
     }, {});
   });
 
-  afterAll(function() {
+  afterAll(function () {
     delete CMS.Models.DummyModel;
     delete CMS.Models.DummyJoin;
     delete CMS.Models.Mixins.dummyable;
   });
 
-  describe("::setup", function() {
+  describe('::setup', function () {
+    it('prefers pre-set static names over root object & collection',
+      function () {
+        var Model = can.Model.Cacheable.extend('CSM.Models.Dummy', {
+          root_object: 'wrong_name',
+          root_collection: 'wrong_names',
+          model_singular: 'RightName',
+          table_singular: 'right_name',
+          title_singular: 'Right Name',
+          model_plural: 'RightNames',
+          table_plural: 'right_names',
+          title_plural: 'Right Names'
+        }, {});
+        // note that these are not explicit in beforeAll above.
+        // model singular is CamelCased form of root_object
+        expect(Model.model_singular).toBe('RightName');
+        // table singular is under_scored version of same
+        expect(Model.table_singular).toBe('right_name');
+        // title singular is 'Human Readable' version of same
+        expect(Model.title_singular).toBe('Right Name');
+        // plurals are based on root collection.
+        expect(Model.model_plural).toBe('RightNames');
+        expect(Model.table_plural).toBe('right_names');
+        expect(Model.title_plural).toBe('Right Names');
+      }
+    );
 
-    it("prefers pre-set static names over root object & collection", function() {
-      var Model = can.Model.Cacheable.extend("CSM.Models.Dummy", {
-        root_object: "wrong_name",
-        root_collection: "wrong_names",
-        model_singular: "RightName",
-        table_singular: "right_name",
-        title_singular: "Right Name",
-        model_plural: "RightNames",
-        table_plural: "right_names",
-        title_plural: "Right Names"
-      }, {});
-      // note that these are not explicit in beforeAll above.
-      // model singular is CamelCased form of root_object
-      expect(Model.model_singular).toBe("RightName");
-      // table singular is under_scored version of same
-      expect(Model.table_singular).toBe("right_name");
-      // title singular is "Human Readable" version of same
-      expect(Model.title_singular).toBe("Right Name");
-      // plurals are based on root collection.
-      expect(Model.model_plural).toBe("RightNames");
-      expect(Model.table_plural).toBe("right_names");
-      expect(Model.title_plural).toBe("Right Names");
+    it('sets various forms of the name based on root object & collection ' +
+      'by default',
+      function () {
+        // note that these are not explicit in beforeAll above.
+        // model singular is CamelCased form of root_object
+        expect(CMS.Models.DummyModel.model_singular).toBe('DummyModel');
+        // table singular is under_scored version of same
+        expect(CMS.Models.DummyModel.table_singular).toBe('dummy_model');
+        // title singular is 'Human Readable' version of same
+        expect(CMS.Models.DummyModel.title_singular).toBe('Dummy Model');
+        // plurals are based on root collection.
+        expect(CMS.Models.DummyModel.model_plural).toBe('DummyModels');
+        expect(CMS.Models.DummyModel.table_plural).toBe('dummy_models');
+        expect(CMS.Models.DummyModel.title_plural).toBe('Dummy Models');
+      }
+    );
+
+    it('sets findAll to default based on root_collection if not set',
+      function () {
+        var Model;
+        spyOn(can.Model, 'setup');
+        Model = can.Model.Cacheable.extend(
+          'CMS.Models.DummyFind',
+          {root_collection: 'foos'},
+          {}
+        );
+        expect(Model.findAll).toBe('GET /api/foos');
+      }
+    );
+
+    it('applies mixins based on the mixins property', function () {
+      expect(CMS.Models.Mixins.dummyable.add_to)
+        .toHaveBeenCalledWith(CMS.Models.DummyModel);
     });
 
-    it("sets various forms of the name based on root object & collection by default", function() {
-      // note that these are not explicit in beforeAll above.
-      // model singular is CamelCased form of root_object
-      expect(CMS.Models.DummyModel.model_singular).toBe("DummyModel");
-      // table singular is under_scored version of same
-      expect(CMS.Models.DummyModel.table_singular).toBe("dummy_model");
-      // title singular is "Human Readable" version of same
-      expect(CMS.Models.DummyModel.title_singular).toBe("Dummy Model");
-      // plurals are based on root collection.
-      expect(CMS.Models.DummyModel.model_plural).toBe("DummyModels");
-      expect(CMS.Models.DummyModel.table_plural).toBe("dummy_models");
-      expect(CMS.Models.DummyModel.title_plural).toBe("Dummy Models");
-    });
-
-    it("sets findAll to default based on root_collection if not set", function() {
-      spyOn(can.Model, "setup");
-      var Model = can.Model.Cacheable.extend("CMS.Models.DummyFind", { root_collection: "foos" }, {});
-      expect(Model.findAll).toBe("GET /api/foos");
-    });
-
-    it("applies mixins based on the mixins property", function() {
-      expect(CMS.Models.Mixins.dummyable.add_to).toHaveBeenCalledWith(CMS.Models.DummyModel);
-    });
-
-    it("merges in default attributes for created_at and updated_at", function() {
-      expect(CMS.Models.DummyModel.attributes).toEqual({
-        created_at: "datetime",
-        updated_at: "datetime",
-        dummy_attribute: "dummy_convert"
-      });
-    });
-
+    it('merges in default attributes for created_at and updated_at',
+      function () {
+        expect(CMS.Models.DummyModel.attributes).toEqual({
+          created_at: 'datetime',
+          updated_at: 'datetime',
+          dummy_attribute: 'dummy_convert'
+        });
+      }
+    );
   });
 
-  describe("::init", function() {
-
-    it("sets custom attributes", function() {
-      // NB using $.extend here creates a new object with all of the static properties of the function.
-      //  This is how the custom attributable is implemented in setup.
-      expect(GGRC.custom_attributable_types).toContain($.extend({}, CMS.Models.DummyModel));
+  describe('::init', function () {
+    it('sets custom attributes', function () {
+      // NB using $.extend here creates a new object with all of the static
+      // properties of the function. This is how the custom attributable
+      // is implemented in setup.
+      expect(GGRC.custom_attributable_types)
+        .toContain($.extend({}, CMS.Models.DummyModel));
     });
-
   });
 
-
-  describe("::makeDestroy", function() {
-
+  describe('::makeDestroy', function () {
     var destroy_spy;
-    beforeEach(function() {
-      destroy_spy = jasmine.createSpy("destroy");
-      spyOn(CMS.Models.BackgroundTask, "findOne").and.returnValue($.when());
+    beforeEach(function () {
+      destroy_spy = jasmine.createSpy('destroy');
+      spyOn(CMS.Models.BackgroundTask, 'findOne').and.returnValue($.when());
     });
 
-    it("finds background task if specified in return object", function(done) {
+    it('finds background task if specified in return object', function (done) {
       var destroy = CMS.Models.DummyModel.makeDestroy(destroy_spy);
-      destroy_spy.and.returnValue($.when({ background_task: {id: 1}}));
+      destroy_spy.and.returnValue($.when({background_task: {id: 1}}));
 
-      destroy(2).then(function() {
-        expect(CMS.Models.BackgroundTask.findOne).toHaveBeenCalledWith({ id: 1 });
+      destroy(2).then(function () {
+        expect(CMS.Models.BackgroundTask.findOne)
+          .toHaveBeenCalledWith({id: 1});
         done();
       }, failAll(done));
     });
 
-    it("polls background task if found", function(done) {
+    it('polls background task if found', function (done) {
       var destroy = CMS.Models.DummyModel.makeDestroy(destroy_spy);
-      var poll_spy = jasmine.createSpyObj("poll_spy", ["poll"]);
-      destroy_spy.and.returnValue($.when({ background_task: {id: 1}}));
+      var poll_spy = jasmine.createSpyObj('poll_spy', ['poll']);
+      destroy_spy.and.returnValue($.when({background_task: {id: 1}}));
       CMS.Models.BackgroundTask.findOne.and.returnValue($.when(poll_spy));
 
-      destroy(2).then(function() {
-        expect(CMS.Models.BackgroundTask.findOne).toHaveBeenCalledWith({ id: 1 });
+      destroy(2).then(function () {
+        expect(CMS.Models.BackgroundTask.findOne)
+          .toHaveBeenCalledWith({id: 1});
         expect(poll_spy.poll).toHaveBeenCalled();
         done();
       }, failAll(done));
     });
 
-    it("continues normally if no background task specified", function(done) {
+    it('continues normally if no background task specified', function (done) {
       var destroy = CMS.Models.DummyModel.makeDestroy(destroy_spy);
-      destroy_spy.and.returnValue($.when({ dummy: {id: 1}}));
+      destroy_spy.and.returnValue($.when({dummy: {id: 1}}));
 
-      destroy(2).then(function() {
+      destroy(2).then(function () {
         expect(CMS.Models.BackgroundTask.findOne).not.toHaveBeenCalled();
         done();
       }, failAll(done));
     });
-
   });
 
-  describe("::update", function() {
+  describe('::update', function () {
+    var _obj;
+    var id = 0;
 
-    var _obj, id = 0;
-
-    beforeEach(function(done) {
-      _obj = new CMS.Models.DummyModel({ id: ++id });
+    beforeEach(function (done) {
+      _obj = new CMS.Models.DummyModel({id: ++id});
       done();
     });
 
-    it("processes args before sending", function(done) {
+    it('processes args before sending', function (done) {
       var obj = _obj;
-      spyOn(CMS.Models.DummyModel, "process_args");
-      spyOn(can, "ajax").and.returnValue($.when({}));
-      CMS.Models.DummyModel.update(obj.id, obj).then(function() {
+      spyOn(CMS.Models.DummyModel, 'process_args');
+      spyOn(can, 'ajax').and.returnValue($.when({}));
+      CMS.Models.DummyModel.update(obj.id, obj).then(function () {
         expect(CMS.Models.DummyModel.process_args).toHaveBeenCalledWith(obj);
         done();
       });
     });
 
-    it("calls resolve_deferred_bindings after send success", function(done) {
+    it('calls resolve_deferred_bindings after send success', function (done) {
       var obj = _obj;
-      spyOn(CMS.Models.DummyModel, "resolve_deferred_bindings").and.returnValue(obj);
-      spyOn(can, "ajax").and.returnValue($.when({ dummy_model: {id: obj.id}}));
-      CMS.Models.DummyModel.update(obj.id, obj.serialize()).then(function() {
-        expect(CMS.Models.DummyModel.resolve_deferred_bindings).toHaveBeenCalledWith(obj);
-        setTimeout(function() {
-          done();
-        }, 10);
-      }, failAll(done));
-
+      spyOn(CMS.Models.DummyModel, 'resolve_deferred_bindings')
+        .and.returnValue(obj);
+      spyOn(can, 'ajax')
+        .and.returnValue($.when({dummy_model: {id: obj.id}}));
+      CMS.Models.DummyModel
+        .update(obj.id, obj.serialize())
+        .then(
+          function () {
+            expect(CMS.Models.DummyModel.resolve_deferred_bindings)
+              .toHaveBeenCalledWith(obj);
+            setTimeout(function () {
+              done();
+            }, 10);
+          },
+          failAll(done)
+        );
     });
 
-    describe("update conflict", function() {
+    describe('update conflict', function () {
+      it('triggers error flash when one property has an update conflict',
+        function (done) {
+          var obj = _obj;
+          obj.attr('foo', 'bar');
+          obj.backup();
+          expect(obj._backupStore)
+            .toEqual(jasmine.objectContaining({id: obj.id, foo: 'bar'}));
+          obj.attr('foo', 'plonk');
+          spyOn($.fn, 'trigger').and.callThrough();
+          spyOn(obj, 'save').and.callFake(function () {
+            return new $.Deferred(function (dfd) {
+              setTimeout(function () {
+                dfd.resolve(obj);
+              }, 10);
+            });
+          });
+          spyOn(obj, 'refresh').and.callFake(function () {
+            // uh-oh!  The same attr has been changed locally and remotely!
+            obj.attr('foo', 'thud');
+            return new $.Deferred(function (dfd) {
+              setTimeout(function () {
+                dfd.resolve(obj);
+              }, 10);
+            });
+          });
+          spyOn(can, 'ajax').and.callFake(function () {
+            return new $.Deferred(function (dfd) {
+              setTimeout(function () {
+                dfd.reject({status: 409}, 409, 'CONFLICT');
+              }, 10);
+            });
+          });
+          CMS.Models.DummyModel
+            .update(obj.id.toString(), obj.serialize())
+            .then(
+              function () {
+                fail('The update handler isn\'t supposed to resolve here.');
+                done();
+              },
+              function () {
+                expect($.fn.trigger).toHaveBeenCalledWith(
+                  'ajax:flash', {warning: [jasmine.any(String)]});
+                setTimeout(function () {
+                  done();
+                }, 10);
+              }
+            );
+        }
+      );
 
-      it("triggers error flash when one property has an update conflict", function(done) {
+      it('refreshes model', function (done) {
         var obj = _obj;
-        obj.attr("foo", "bar");
-        obj.backup();
-        expect(obj._backupStore).toEqual(jasmine.objectContaining({ id: obj.id, foo: "bar" }));
-        obj.attr("foo", "plonk");
-        spyOn($.fn, "trigger").and.callThrough();
-        spyOn(obj, "save").and.callFake(function() {
-          return new $.Deferred(function(dfd) {
-            setTimeout(function() {
-              dfd.resolve(obj);
-            }, 10);
-          });
-        });
-        spyOn(obj, "refresh").and.callFake(function() {
-          obj.attr("foo", "thud"); //uh-oh!  The same attr has been changed locally and remotely!
-          return new $.Deferred(function(dfd) {
-            setTimeout(function() {
-              dfd.resolve(obj);
-            }, 10);
-          });
-        });
-        spyOn(can, "ajax")//.and.returnValue(new $.Deferred().reject({status: 409}, 409, "CONFLICT"));
-        .and.callFake(function() {
-          return new $.Deferred(function(dfd) {
-            setTimeout(function() {
-              dfd.reject({status: 409}, 409, "CONFLICT");
-            }, 10);
-          });
-        });
-        CMS.Models.DummyModel.update(obj.id.toString(), obj.serialize()).then(function() {
-          fail("The update handler isn't supposed to resolve here.");
-          done();
-        }, function() {
-          expect($.fn.trigger).toHaveBeenCalledWith("ajax:flash", {warning : [ jasmine.any(String) ] });
-          setTimeout(function() {
-            done();
-          }, 10);
-        });
-      });
-
-      it("refreshes model", function(done) {
-        var obj = _obj;
-        spyOn(obj, "refresh").and.returnValue($.when(obj));
-        spyOn(can, "ajax").and.returnValue(new $.Deferred().reject({status: 409}, 409, "CONFLICT"));
-        CMS.Models.DummyModel.update(obj.id, obj.serialize()).then(function() {
+        spyOn(obj, 'refresh').and.returnValue($.when(obj));
+        spyOn(can, 'ajax').and.returnValue(
+          new $.Deferred().reject({status: 409}, 409, 'CONFLICT')
+        );
+        CMS.Models.DummyModel.update(obj.id, obj.serialize()).then(function () {
           expect(obj.refresh).toHaveBeenCalledWith();
-          setTimeout(function() {
+          setTimeout(function () {
             done();
           }, 10);
         }, failAll(done));
       });
 
-      it("merges changed properties and saves", function(done) {
+      it('merges changed properties and saves', function (done) {
         var obj = _obj;
-        obj.attr("foo", "bar");
+        obj.attr('foo', 'bar');
         obj.backup();
-        expect(obj._backupStore).toEqual(jasmine.objectContaining({ id: obj.id, foo: "bar" }));
-        obj.attr("foo", "plonk");
-        spyOn(obj, "save").and.returnValue($.when(obj));
-        spyOn(obj, "refresh").and.callFake(function() {
-          obj.attr("baz", "quux");
+        expect(obj._backupStore)
+          .toEqual(jasmine.objectContaining({id: obj.id, foo: 'bar'}));
+        obj.attr('foo', 'plonk');
+        spyOn(obj, 'save').and.returnValue($.when(obj));
+        spyOn(obj, 'refresh').and.callFake(function () {
+          obj.attr('baz', 'quux');
           return $.when(obj);
         });
-        spyOn(can, "ajax").and.returnValue(new $.Deferred().reject({status: 409}, 409, "CONFLICT"));
-        CMS.Models.DummyModel.update(obj.id, obj.serialize()).then(function() {
-          expect(obj).toEqual(jasmine.objectContaining({ id: obj.id, foo: "plonk", baz: "quux"}));
-          expect(obj.save).toHaveBeenCalled();
-          setTimeout(function() {
-            done();
-          }, 10);
-        }, failAll(done));
+        spyOn(can, 'ajax').and.returnValue(
+          new $.Deferred().reject({status: 409}, 409, 'CONFLICT')
+        );
+
+        CMS.Models.DummyModel
+          .update(obj.id, obj.serialize())
+          .then(
+            function () {
+              expect(obj).toEqual(
+                jasmine.objectContaining({
+                  id: obj.id,
+                  foo: 'plonk',
+                  baz: 'quux'})
+              );
+              expect(obj.save).toHaveBeenCalled();
+              setTimeout(function () {
+                done();
+              }, 10);
+            },
+            failAll(done)
+          );
       });
 
-      it("lets other error statuses pass through", function(done) {
-        var obj = new CMS.Models.DummyModel({ id: 1 });
+      it('lets other error statuses pass through', function (done) {
+        var obj = new CMS.Models.DummyModel({id: 1});
         var xhr = {status: 400};
-        spyOn(obj, "refresh").and.returnValue($.when(obj.serialize()));
-        spyOn(can, "ajax").and.returnValue(new $.Deferred().reject(xhr, 400, "BAD REQUEST"));
+        spyOn(obj, 'refresh').and.returnValue($.when(obj.serialize()));
+        spyOn(can, 'ajax').and.returnValue(
+          new $.Deferred().reject(xhr, 400, 'BAD REQUEST')
+        );
         CMS.Models.DummyModel.update(1, obj.serialize()).then(
           failAll(done),
-          function(_xhr) {
+          function (_xhr) {
             expect(_xhr).toBe(xhr);
             done();
           }
         );
       });
     });
-
   });
 
-  describe("::resolve_deferred_bindings", function() {
+  describe('::resolve_deferred_bindings', function () {
+    it('iterates _pending_joins, calling refresh_stubs on each binding',
+      function () {
+        var instance = jasmine.createSpyObj('instance', ['get_binding']);
+        var binding = jasmine.createSpyObj('binding', ['refresh_stubs']);
+        instance._pending_joins = [
+          {what: {}, how: 'add', through: 'foo'}
+        ];
+        instance.get_binding.and.returnValue(binding);
+        spyOn($.when, 'apply').and.returnValue(new $.Deferred().reject());
 
-    it("iterates _pending_joins, calling refresh_stubs on each binding", function() {
+        can.Model.Cacheable.resolve_deferred_bindings(instance);
+        expect(binding.refresh_stubs).toHaveBeenCalled();
+      }
+    );
 
-      var instance = jasmine.createSpyObj("instance", ["get_binding"]);
-      var binding = jasmine.createSpyObj("binding", ["refresh_stubs"]);
-      instance._pending_joins = [{ what: {}, how: "add", through: "foo" }];
-      instance.get_binding.and.returnValue(binding);
-      spyOn($.when, "apply").and.returnValue(new $.Deferred().reject());
+    describe('add case', function () {
+      var instance;
+      var binding;
+      var dummy;
 
-      can.Model.Cacheable.resolve_deferred_bindings(instance);
-      expect(binding.refresh_stubs).toHaveBeenCalled();
-
-    });
-
-    describe("add case", function() {
-
-      var instance, binding, dummy;
-      beforeEach(function() {
-        dummy = new CMS.Models.DummyModel({id:1});
-        instance = jasmine.createSpyObj("instance", ["get_binding", "isNew", "refresh", "attr"]);
-        binding = jasmine.createSpyObj("binding", ["refresh_stubs"]);
-        instance._pending_joins = [{ what: dummy, how: "add", through: "foo" }];
+      beforeEach(function () {
+        dummy = new CMS.Models.DummyModel({id: 1});
+        instance = jasmine.createSpyObj(
+          'instance', ['get_binding', 'isNew', 'refresh', 'attr']);
+        binding = jasmine.createSpyObj('binding', ['refresh_stubs']);
+        instance._pending_joins = [
+          {what: dummy, how: 'add', through: 'foo'}
+        ];
         instance.isNew.and.returnValue(false);
         instance.get_binding.and.returnValue(binding);
-        binding.loader = { model_name: "DummyJoin" };
+        binding.loader = {model_name: 'DummyJoin'};
         binding.list = [];
-        spyOn(CMS.Models.DummyJoin, "newInstance");
-        spyOn(CMS.Models.DummyJoin.prototype, "save");
+        spyOn(CMS.Models.DummyJoin, 'newInstance');
+        spyOn(CMS.Models.DummyJoin.prototype, 'save');
       });
 
-      afterEach(function() {
+      afterEach(function () {
         delete CMS.Models.DummyModel.cache[1];
       });
 
-      it("creates a proxy object when it does not exist", function() {
+      it('creates a proxy object when it does not exist', function () {
         can.Model.Cacheable.resolve_deferred_bindings(instance);
         expect(CMS.Models.DummyJoin.newInstance).toHaveBeenCalled();
         expect(CMS.Models.DummyJoin.prototype.save).toHaveBeenCalled();
       });
 
-      it("does not create proxy object when it already exists", function() {
-        binding.list.push({ instance: dummy });
+      it('does not create proxy object when it already exists', function () {
+        binding.list.push({instance: dummy});
         can.Model.Cacheable.resolve_deferred_bindings(instance);
         expect(CMS.Models.DummyJoin.newInstance).not.toHaveBeenCalled();
         expect(CMS.Models.DummyJoin.prototype.save).not.toHaveBeenCalled();
       });
-
     });
 
+    describe('remove case', function () {
+      var instance;
+      var binding;
+      var dummy;
+      var dummy_join;
 
-    describe("remove case", function() {
-
-      var instance, binding, dummy, dummy_join;
-      beforeEach(function() {
-        dummy = new CMS.Models.DummyModel({id:1});
-        dummy_join = new CMS.Models.DummyJoin({id:1});
-        instance = jasmine.createSpyObj("instance", ["get_binding", "isNew", "refresh", "attr"]);
-        binding = jasmine.createSpyObj("binding", ["refresh_stubs"]);
-        instance._pending_joins = [{ what: dummy, how: "remove", through: "foo" }];
+      beforeEach(function () {
+        dummy = new CMS.Models.DummyModel({id: 1});
+        dummy_join = new CMS.Models.DummyJoin({id: 1});
+        instance = jasmine.createSpyObj(
+          'instance', ['get_binding', 'isNew', 'refresh', 'attr']);
+        binding = jasmine.createSpyObj('binding', ['refresh_stubs']);
+        instance._pending_joins = [
+          {what: dummy, how: 'remove', through: 'foo'}
+        ];
         instance.isNew.and.returnValue(false);
         instance.get_binding.and.returnValue(binding);
-        binding.loader = { model_name: "DummyJoin" };
+        binding.loader = {model_name: 'DummyJoin'};
         binding.list = [];
-        spyOn(CMS.Models.DummyJoin, "newInstance");
-        spyOn(CMS.Models.DummyJoin.prototype, "save");
+        spyOn(CMS.Models.DummyJoin, 'newInstance');
+        spyOn(CMS.Models.DummyJoin.prototype, 'save');
       });
 
-      it("removes proxy object if it exists", function() {
-        binding.list.push({instance: dummy, get_mappings: function() {return [dummy_join]; }});
-        spyOn(dummy_join, "refresh").and.returnValue($.when());
-        spyOn(dummy_join, "destroy");
+      it('removes proxy object if it exists', function () {
+        binding.list.push({
+          instance: dummy,
+          get_mappings: function () {
+            return [dummy_join];
+          }
+        });
+        spyOn(dummy_join, 'refresh').and.returnValue($.when());
+        spyOn(dummy_join, 'destroy');
         can.Model.Cacheable.resolve_deferred_bindings(instance);
         expect(dummy_join.destroy).toHaveBeenCalled();
       });
-
     });
-
   });
 
+  describe('::findAll', function () {
+    it('throws errors when called directly on Cacheable instead of a subclass',
+      function () {
+        expect(can.Model.Cacheable.findAll).toThrow(
+          'No default findAll() exists for subclasses of Cacheable'
+        );
+      }
+    );
 
-  describe("::findAll", function() {
-
-    it("throws errors when called directly on Cacheable instead of a subclass", function() {
-      expect(can.Model.Cacheable.findAll).toThrow(
-        "No default findAll() exists for subclasses of Cacheable"
+    it('unboxes collections when passed back from the find', function (done) {
+      spyOn(can, 'ajax').and.returnValue(
+        $.when({dummy_models_collection: {dummy_models: [{id: 1}]}})
       );
-    });
 
-    it("unboxes collections when passed back from the find", function(done) {
-      spyOn(can, "ajax").and.returnValue($.when({ dummy_models_collection: { dummy_models: [{id: 1}] }}));
-      CMS.Models.DummyModel.findAll().then(function(data) {
+      CMS.Models.DummyModel.findAll().then(function (data) {
         expect(can.ajax).toHaveBeenCalled();
         expect(data).toEqual(jasmine.any(can.List));
         expect(data.length).toBe(1);
         expect(data[0]).toEqual(jasmine.any(CMS.Models.DummyModel));
-        expect(data[0]).toEqual(jasmine.objectContaining({ id: 1 }));
+        expect(data[0]).toEqual(jasmine.objectContaining({id: 1}));
         done();
       }, failAll(done));
     });
 
-    it("makes a collection of a single object when passed back from the find", function(done) {
-      spyOn(can, "ajax").and.returnValue($.when({id: 1}));
-      CMS.Models.DummyModel.findAll().then(function(data) {
-        expect(can.ajax).toHaveBeenCalled();
-        expect(data).toEqual(jasmine.any(can.List));
-        expect(data.length).toBe(1);
-        expect(data[0]).toEqual(jasmine.any(CMS.Models.DummyModel));
-        expect(data[0]).toEqual(jasmine.objectContaining({ id: 1 }));
-        done();
-      }, failAll(done));
-    });
+    it('makes a collection of a single object when passed back from the find',
+      function (done) {
+        spyOn(can, 'ajax').and.returnValue($.when({id: 1}));
+        CMS.Models.DummyModel.findAll().then(function (data) {
+          expect(can.ajax).toHaveBeenCalled();
+          expect(data).toEqual(jasmine.any(can.List));
+          expect(data.length).toBe(1);
+          expect(data[0]).toEqual(jasmine.any(CMS.Models.DummyModel));
+          expect(data[0]).toEqual(jasmine.objectContaining({id: 1}));
+          done();
+        }, failAll(done));
+      }
+    );
 
     // NB -- This unit test is brittle.  It's difficult to unit test for
-    //  things like timing, and it's a bit of a hack to spy on Date.now()
-    //  since that function is used in more places than just our modelize function.
-    //  -- BM 2015-02-03
-    it("only pushes instances into the list for 100ms before yielding", function(done) {
-      var list = new CMS.Models.DummyModel.List();
-      var dummy_models = [
+    // things like timing, and it's a bit of a hack to spy on Date.now()
+    // since that function is used in more places than just our modelize
+    // function. -- BM 2015-02-03
+    it('only pushes instances into the list for 100ms before yielding',
+      function (done) {
+        var st;
+        var list = new CMS.Models.DummyModel.List();
+        var dummy_models = [
           {id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}, {id: 7}
         ];
-      // Have our modelized instances ready for when
-      var dummy_insts = CMS.Models.DummyModel.models(dummy_models);
-      // we want to see how our observable list gets items over time, so spy on the push method
-      spyOn(list, "push").and.callThrough();
-      spyOn(can, "ajax").and.returnValue($.when(dummy_models));
-      var st = 4; // preload Date.now() because it's called once before we even get to modelizing
-      spyOn(Date, "now").and.callFake(function() {
-        // Date.now() is called once at the start of modelizeMS (internal function in findAll)
-        //  once in an unknown location
-        //  and once per item.
-        if((++st % 5) === 0)
-          st += 100; // after three, push the time ahead 100ms to force a new call to modelizeMS
-        return st;
-      });
-      // return model instances for the list of returned items from the server
-      spyOn(CMS.Models.DummyModel.List, "newInstance").and.returnValue(list);
-      //spy so we don't return the list to observe more than once.  That is,
-      //  models calls new DummyModel.List() which we're already spying out,
-      //  so spy models() out in order to *not* call it.
-      spyOn(CMS.Models.DummyModel, "models").and.callFake(function(items) {
-        var ids = can.map(items, function(item) { return item.id; });
-        return can.map(dummy_insts, function(inst) {
-          return ~can.inArray(inst.id, ids) ? inst : undefined;
+
+        // Have our modelized instances ready for when
+        var dummy_insts = CMS.Models.DummyModel.models(dummy_models);
+
+        // we want to see how our observable list gets items over time,
+        // so spy on the push method
+        spyOn(list, 'push').and.callThrough();
+        spyOn(can, 'ajax').and.returnValue($.when(dummy_models));
+
+        // preload Date.now() because it's called once before we even
+        // get to modelizing
+        st = 4;
+        spyOn(Date, 'now').and.callFake(function () {
+          // Date.now() is called once at the start of modelizeMS (internal
+          // function in findAll) once in an unknown location and once per item.
+          if ((++st % 5) === 0) {
+            // after three, push the time ahead 100ms to force a new
+            // call to modelizeMS
+            st += 100;
+          }
+          return st;
         });
-      });
-      CMS.Models.DummyModel.findAll().then(function() {
-        // finally, we show that with the 100ms gap between pushing ids 3 and 4, we force a separate push.
-        expect(list.push).toHaveBeenCalledWith(
-          jasmine.objectContaining({id: 1}),
-          jasmine.objectContaining({id: 2}),
-          jasmine.objectContaining({id: 3})
-        );
-        expect(list.push).toHaveBeenCalledWith(
-          jasmine.objectContaining({id: 4}),
-          jasmine.objectContaining({id: 5}),
-          jasmine.objectContaining({id: 6})
-        );
-        expect(list.push).toHaveBeenCalledWith(
-          jasmine.objectContaining({id: 7})
-        );
-        done();
-      }, failAll(done));
-    });
-
+        // return model instances for the list of returned items from the server
+        spyOn(CMS.Models.DummyModel.List, 'newInstance').and.returnValue(list);
+        // spy so we don't return the list to observe more than once.  That is,
+        // models calls new DummyModel.List() which we're already spying out,
+        // so spy models() out in order to *not* call it.
+        spyOn(CMS.Models.DummyModel, 'models').and.callFake(function (items) {
+          var ids = can.map(items, function (item) {
+            return item.id;
+          });
+          return can.map(dummy_insts, function (inst) {
+            return ~can.inArray(inst.id, ids) ? inst : undefined;
+          });
+        });
+        CMS.Models.DummyModel.findAll().then(function () {
+          // finally, we show that with the 100ms gap between pushing ids 3 and 4, we force a separate push.
+          expect(list.push).toHaveBeenCalledWith(
+            jasmine.objectContaining({id: 1}),
+            jasmine.objectContaining({id: 2}),
+            jasmine.objectContaining({id: 3})
+          );
+          expect(list.push).toHaveBeenCalledWith(
+            jasmine.objectContaining({id: 4}),
+            jasmine.objectContaining({id: 5}),
+            jasmine.objectContaining({id: 6})
+          );
+          expect(list.push).toHaveBeenCalledWith(
+            jasmine.objectContaining({id: 7})
+          );
+          done();
+        }, failAll(done));
+      }
+    );
   });
 
-  describe("::findPage", function() {
-    it("throws errors when called directly on Cacheable instead of a subclass", function() {
-      expect(can.Model.Cacheable.findPage).toThrow(
-       "No default findPage() exists for subclasses of Cacheable"
-      );
-    });
-
+  describe('::findPage', function () {
+    it('throws errors when called directly on Cacheable instead of a subclass',
+      function () {
+        expect(can.Model.Cacheable.findPage).toThrow(
+         'No default findPage() exists for subclasses of Cacheable'
+        );
+      }
+    );
   });
 
-  describe("#refresh", function() {
-
+  describe('#refresh', function () {
     var inst;
-    beforeEach(function() {
-      inst = new CMS.Models.DummyModel({ href : '/api/dummy_models/1' });
-      spyOn(can, "ajax").and.returnValue(new $.Deferred(function(dfd) {
-        setTimeout(function() {
+
+    beforeEach(function () {
+      inst = new CMS.Models.DummyModel({href: '/api/dummy_models/1'});
+      spyOn(can, 'ajax').and.returnValue(new $.Deferred(function (dfd) {
+        setTimeout(function () {
           dfd.resolve(inst.serialize());
         }, 10);
       }));
     });
-    afterEach(function() {
+    afterEach(function () {
       delete CMS.Models.DummyModel.cache[undefined];
     });
 
-    it("calls the object endpoint with the supplied href if no selfLink", function(done) {
-      inst.refresh().then(function() {
-        expect(can.ajax).toHaveBeenCalledWith(jasmine.objectContaining({
-          url: "/api/dummy_models/1",
-          type: "get"
-        }));
-        done();
-      }, fail);
-    });
+    it('calls the object endpoint with the supplied href if no selfLink',
+      function (done) {
+        inst.refresh().then(function () {
+          expect(can.ajax).toHaveBeenCalledWith(jasmine.objectContaining({
+            url: '/api/dummy_models/1',
+            type: 'get'
+          }));
+          done();
+        }, fail);
+      }
+    );
 
-    it("throttles the requests to once per second", function(done) {
+    it('throttles the requests to once per second', function (done) {
       inst.refresh();
       inst.refresh();
-      setTimeout(function() {
-        inst.refresh().then(function() {
+      setTimeout(function () {
+        inst.refresh().then(function () {
           expect(can.ajax.calls.count()).toBe(2);
           done();
         }, fail);
-      }, 1000); // 1000ms is enough to trigger a new call to the debounced function
-      inst.refresh().then(function() {
+      }, 1000); // 1000ms is enough to trigger a new call to the debounced func
+      inst.refresh().then(function () {
         expect(can.ajax.calls.count()).toBe(1);
       }, fail);
     });
 
-    it("backs up the refreshed state immediately after refreshing", function(done) {
-      spyOn(CMS.Models.DummyModel, "model").and.returnValue(inst);
-      spyOn(inst, "backup");
-      inst.refresh().then(function() {
-        expect(inst.backup).toHaveBeenCalled();
-        done();
-      }, fail);
-    });
+    it('backs up the refreshed state immediately after refreshing',
+      function (done) {
+        spyOn(CMS.Models.DummyModel, 'model').and.returnValue(inst);
+        spyOn(inst, 'backup');
+        inst.refresh().then(function () {
+          expect(inst.backup).toHaveBeenCalled();
+          done();
+        }, fail);
+      }
+    );
   });
 
-  describe("::parse_deep_property_descriptor", function() {
-    it("produces an immutable descriptor", function() {
-      var desc = can.Model.Cacheable.parse_deep_property_descriptor("foo.bar|baz|quux"),
-          zero = desc[0][0];
-          one = desc[1];
+  describe('::parse_deep_property_descriptor', function () {
+    it('produces an immutable descriptor', function () {
+      var desc =
+        can.Model.Cacheable.parse_deep_property_descriptor('foo.bar|baz|quux');
+      var zero = desc[0][0];
+      var one = desc[1];
 
       try {
         desc[0][0] = 0;
@@ -519,47 +601,48 @@ describe("can.Model.Cacheable", function() {
     });
   });
 
-  describe("#get_deep_property", function() {
+  describe('#get_deep_property', function () {
     var equip = function (value) {
-      if (typeof value === "object") {
-        value.get_deep_property = can.Model.Cacheable.prototype.get_deep_property;
+      if (typeof value === 'object') {
+        value.get_deep_property =
+          can.Model.Cacheable.prototype.get_deep_property;
         _.each(value, equip);
       }
       return value;
     };
     var get = function (key, value) {
-       var desc = can.Model.Cacheable.parse_deep_property_descriptor(key);
-       return equip(value).get_deep_property(desc);
+      var desc = can.Model.Cacheable.parse_deep_property_descriptor(key);
+      return equip(value).get_deep_property(desc);
     };
 
-    it("gets a simple property", function() {
-      expect(get("foo", {foo: "bar"})).toBe("bar");
-      expect(get("foo", {foo: 2})).toBe(2);
-      expect(get("foo", {})).toBe(null);
+    it('gets a simple property', function () {
+      expect(get('foo', {foo: 'bar'})).toBe('bar');
+      expect(get('foo', {foo: 2})).toBe(2);
+      expect(get('foo', {})).toBe(null);
     });
 
-    it("gets a nested property", function() {
+    it('gets a nested property', function () {
       var value = {
-        foo: "bar",
+        foo: 'bar',
         bar: {
           foo: 1,
-          bar: "2",
-          baz: { foo: "foo" }
+          bar: '2',
+          baz: {foo: 'foo'}
         }
       };
-      expect(get("foo", value)).toBe("bar");
-      expect(get("bar", value)).toBe(value.bar);
-      expect(get("bar.foo", value)).toBe(1);
-      expect(get("bar.bar", value)).toBe("2");
-      expect(get("bar.baz.foo", value)).toBe("foo");
+      expect(get('foo', value)).toBe('bar');
+      expect(get('bar', value)).toBe(value.bar);
+      expect(get('bar.foo', value)).toBe(1);
+      expect(get('bar.bar', value)).toBe('2');
+      expect(get('bar.baz.foo', value)).toBe('foo');
     });
 
-    it("gets and element from an array", function() {
-      expect(get("0.1", [[undefined, 2],[]])).toBe(2);
-      expect(get("a.1", {a:["foo", "bar"]})).toBe("bar");
+    it('gets and element from an array', function () {
+      expect(get('0.1', [[undefined, 2], []])).toBe(2);
+      expect(get('a.1', {a: ['foo', 'bar']})).toBe('bar');
     });
 
-    it("chooses first non-empty", function() {
+    it('chooses first non-empty', function () {
       var value1 = {
         foo: {
           bar: {
@@ -574,43 +657,42 @@ describe("can.Model.Cacheable", function() {
           }
         }
       };
-      expect(get("foo.bar|baz.quux", value1)).toBe(3);
-      expect(get("foo.bar|baz.quux", value2)).toBe(3);
+      expect(get('foo.bar|baz.quux', value1)).toBe(3);
+      expect(get('foo.bar|baz.quux', value2)).toBe(3);
     });
 
-    it("automatically calls reify when available", function() {
+    it('automatically calls reify when available', function () {
       var value = {
         foo: {
-          reify: function() {
-            return { bar: "baz" };
+          reify: function () {
+            return {bar: 'baz'};
           }
         }
-      }
-      expect(get("foo.bar", value)).toBe("baz");
+      };
+      expect(get('foo.bar', value)).toBe('baz');
     });
 
-    it("does a multi-get for GET_ALL", function() {
+    it('does a multi-get for GET_ALL', function () {
       var value = {
         foo: [
-            { bar: 1 },
-            { bar: 2 },
-            { baz: 3 }
-          ]
+          {bar: 1},
+          {bar: 2},
+          {baz: 3}
+        ]
       };
-      expect(get("foo.GET_ALL.bar|baz", value)).toEqual([1,2,3]);
+      expect(get('foo.GET_ALL.bar|baz', value)).toEqual([1, 2, 3]);
     });
 
-    it("produces a tree for nested multi-get", function() {
+    it('produces a tree for nested multi-get', function () {
       var value = {
         foo: [
-            { bar : [{y: 1}, {x: 2}, {x: 3}] },
-            { bar : [{x: 4}, {x: 5}, {y: 6}] },
-            { baz : [{y: 7}, {x: 8}, {x: 9}] },
-          ]
+          {bar: [{y: 1}, {x: 2}, {x: 3}]},
+          {bar: [{x: 4}, {x: 5}, {y: 6}]},
+          {baz: [{y: 7}, {x: 8}, {x: 9}]}
+        ]
       };
-      expect(get("foo.GET_ALL.bar|baz.GET_ALL.x|y", value)).
-        toEqual([[1,2,3], [4,5,6], [7,8,9]]);
+      expect(get('foo.GET_ALL.bar|baz.GET_ALL.x|y', value))
+        .toEqual([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
     });
   });
-
 });

--- a/src/ggrc/assets/js_specs/models/display_prefs_spec.js
+++ b/src/ggrc/assets/js_specs/models/display_prefs_spec.js
@@ -5,400 +5,521 @@
     Maintained By: brad@reciprocitylabs.com
 */
 
+/* global affix: false */
 
-describe("display prefs model", function() {
-  
-  var display_prefs, exp;
-  beforeAll(function() {
+describe('display prefs model', function () {
+  var display_prefs;
+  var exp;
+
+  beforeAll(function () {
     display_prefs = new CMS.Models.DisplayPrefs();
     exp = CMS.Models.DisplayPrefs.exports;
   });
 
-  afterEach(function() {
+  afterEach(function () {
     display_prefs.removeAttr(window.location.pathname);
-    display_prefs.isNew() || display_prefs.destroy();
+    if (!display_prefs.isNew()) {
+      display_prefs.destroy();
+    }
   });
 
-  describe("#init", function( ){
-    it("sets autoupdate to true by default", function() {
+  describe('#init', function () {
+    it('sets autoupdate to true by default', function () {
       expect(display_prefs.autoupdate).toBe(true);
     });
-
   });
 
-  describe("low level accessors", function() {
-    beforeEach(function() {
-      display_prefs.attr("foo", "bar");
-    });
-    
-    afterEach(function() {
-      display_prefs.removeAttr("foo");
-      display_prefs.removeAttr("baz");
+  describe('low level accessors', function () {
+    beforeEach(function () {
+      display_prefs.attr('foo', 'bar');
     });
 
-    describe("#makeObject", function() {
+    afterEach(function () {
+      display_prefs.removeAttr('foo');
+      display_prefs.removeAttr('baz');
+    });
 
-      it("returns the model itself with no args", function() {
+    describe('#makeObject', function () {
+      it('returns the model itself with no args', function () {
         expect(display_prefs.makeObject()).toBe(display_prefs);
       });
 
-      it("returns an empty can.Observe when the key does not resolve to an Observable", function() {
-        expect(display_prefs.makeObject("foo")).not.toBe("bar");
-        var newval = display_prefs.makeObject("baz");
-        expect(newval instanceof can.Observe).toBeTruthy();
-        expect(newval.serialize()).toEqual({});
-      });
+      it('returns an empty can.Observe when the key does not resolve ' +
+        'to an Observable',
+        function () {
+          var newval;
+          expect(display_prefs.makeObject('foo')).not.toBe('bar');
+          newval = display_prefs.makeObject('baz');
+          expect(newval instanceof can.Observe).toBeTruthy();
+          expect(newval.serialize()).toEqual({});
+        }
+      );
 
-      it("makes a nested path of can.Observes when the key has multiple levels", function() {
-        var newval = display_prefs.makeObject("baz", "quux");
-        expect(display_prefs.baz.quux instanceof can.Observe).toBeTruthy();
-      });
-
+      it('makes a nested path of can.Observes when the key has ' +
+        'multiple levels',
+        function () {
+          display_prefs.makeObject('baz', 'quux');
+          expect(display_prefs.baz.quux instanceof can.Observe).toBeTruthy();
+        }
+      );
     });
 
-    describe("#getObject", function() {
-      it("returns a set value whether or not the value is an Observe", function() {
-        expect(display_prefs.getObject("foo")).toBe("bar");
-        display_prefs.makeObject("baz", "quux");
-        expect(display_prefs.getObject("baz").serialize()).toEqual({ "quux" : {}});
-      });
+    describe('#getObject', function () {
+      it('returns a set value whether or not the value is an Observe',
+        function () {
+          expect(display_prefs.getObject('foo')).toBe('bar');
+          display_prefs.makeObject('baz', 'quux');
+          expect(display_prefs.getObject('baz').serialize())
+            .toEqual({quux: {}});
+        }
+      );
 
-      it("returns undefined when the key is not found", function(){
-        expect(display_prefs.getObject("xyzzy")).not.toBeDefined();
+      it('returns undefined when the key is not found', function () {
+        expect(display_prefs.getObject('xyzzy')).not.toBeDefined();
       });
     });
   });
 
-  describe("top nav", function () {
-    afterEach(function() {
+  describe('top nav', function () {
+    afterEach(function () {
       display_prefs.resetPagePrefs();
-      //display_prefs.removeAttr(exp.path);
+      // display_prefs.removeAttr(exp.path);
     });
 
-    describe("hiddenness", function () {
-      it("sets nav hidden", function() {
-        display_prefs.setTopNavHidden("this arg is ignored", true);
-            
+    describe('hiddenness', function () {
+      it('sets nav hidden', function () {
+        display_prefs.setTopNavHidden('this arg is ignored', true);
+
         expect(
-          display_prefs.attr([exp.path, exp.TOP_NAV].join(".")).top_nav.is_hidden
+          display_prefs
+            .attr([exp.path, exp.TOP_NAV].join('.'))
+            .top_nav
+            .is_hidden
         ).toBe(true);
       });
-        
-      it("gets nav hidden", function () {
-        display_prefs.setTopNavHidden("this arg is ignored", true);
-            
+
+      it('gets nav hidden', function () {
+        display_prefs.setTopNavHidden('this arg is ignored', true);
+
         expect(display_prefs.getTopNavHidden()).toBe(true);
       });
-        
-      it("returns false by default", function () {
+
+      it('returns false by default', function () {
         expect(display_prefs.getTopNavHidden()).toBe(false);
       });
-    }); 
+    });
 
-    describe("widget list", function () {
-      it("sets widget list", function () {
-        display_prefs.setTopNavWidgets("this arg is ignored", {a:1, b: 2});
+    describe('widget list', function () {
+      it('sets widget list', function () {
+        display_prefs.setTopNavWidgets('this arg is ignored', {a: 1, b: 2});
 
         expect(
-          display_prefs.attr([exp.path, exp.TOP_NAV].join(".")).top_nav.widget_list.serialize()
+          display_prefs
+            .attr([exp.path, exp.TOP_NAV].join('.'))
+            .top_nav
+            .widget_list
+            .serialize()
         ).toEqual({a: 1, b: 2});
       });
-        
-      it("gets widget list", function () {
-        display_prefs.setTopNavWidgets("this arg is ignored", {a: 1, b: 2});
+
+      it('gets widget list', function () {
+        display_prefs.setTopNavWidgets('this arg is ignored', {a: 1, b: 2});
 
         expect(display_prefs.getTopNavWidgets()).toEqual({a: 1, b: 2});
       });
 
-      it("returns {} by default", function () {
+      it('returns {} by default', function () {
         expect(display_prefs.getTopNavWidgets()).toEqual({});
       });
     });
   });
 
-   describe("filter hiding", function () {
-     afterEach(function() {
-       display_prefs.resetPagePrefs(); 
-     });
+  describe('filter hiding', function () {
+    afterEach(function () {
+      display_prefs.resetPagePrefs();
+    });
 
-     it("sets filter hidden", function() {
-       display_prefs.setFilterHidden(true);
-         
-       expect(
-         display_prefs.attr([exp.path, exp.FILTER_WIDGET].join(".")).filter_widget.is_hidden
-       ).toBe(true);
-     });
-        
-     it("gets filter hidden", function () {
-       display_prefs.setFilterHidden(true);
-            
-       expect(display_prefs.getFilterHidden()).toBe(true);
-     });
-        
-     it("returns false by default", function () {
-       expect(display_prefs.getFilterHidden()).toBe(false);
-     }); 
-   });
+    it('sets filter hidden', function () {
+      display_prefs.setFilterHidden(true);
 
+      expect(
+        display_prefs
+          .attr([exp.path, exp.FILTER_WIDGET].join('.'))
+          .filter_widget
+          .is_hidden
+      ).toBe(true);
+    });
 
-  describe("#setCollapsed", function() {
-    afterEach(function() {
+    it('gets filter hidden', function () {
+      display_prefs.setFilterHidden(true);
+
+      expect(display_prefs.getFilterHidden()).toBe(true);
+    });
+
+    it('returns false by default', function () {
+      expect(display_prefs.getFilterHidden()).toBe(false);
+    });
+  });
+
+  describe('#setCollapsed', function () {
+    afterEach(function () {
       display_prefs.removeAttr(exp.COLLAPSE);
       display_prefs.removeAttr(exp.path);
     });
 
-    it("sets the collapse value for a widget", function() {
-      display_prefs.setCollapsed("this arg is ignored", "foo", true);
+    it('sets the collapse value for a widget', function () {
+      display_prefs.setCollapsed('this arg is ignored', 'foo', true);
 
-      expect(display_prefs.attr([exp.path, exp.COLLAPSE, "foo"].join("."))).toBe(true);
+      expect(
+        display_prefs.attr([exp.path, exp.COLLAPSE, 'foo'].join('.'))
+      ).toBe(true);
     });
   });
 
-  function getSpecs (func, token, fooValue, barValue) {
-    var fooMatcher = typeof fooValue === "object" ? "toEqual" : "toBe";
-    var barMatcher = typeof barValue === "object" ? "toEqual" : "toBe";
+  function getSpecs(func, token, fooValue, barValue) {
+    var fooMatcher = typeof fooValue === 'object' ? 'toEqual' : 'toBe';
+    var barMatcher = typeof barValue === 'object' ? 'toEqual' : 'toBe';
 
-    return function() {
+    return function () {
+      var exp_token;
+
       function getTest() {
-        var fooActual = display_prefs[func]("unit_test", "foo");
-        var barActual = display_prefs[func]("unit_test", "bar");
-       
-        expect(fooActual.serialize ? fooActual.serialize() : fooActual)[fooMatcher](fooValue);
-        expect(barActual.serialize ? barActual.serialize() : barActual)[barMatcher](barValue);
+        var fooActual = display_prefs[func]('unit_test', 'foo');
+        var barActual = display_prefs[func]('unit_test', 'bar');
+
+        expect(
+          fooActual.serialize ? fooActual.serialize() : fooActual
+        )[fooMatcher](fooValue);
+
+        expect(
+          barActual.serialize ? barActual.serialize() : barActual
+        )[barMatcher](barValue);
       }
 
-      var exp_token;
-      beforeEach(function() {
-        exp_token = exp[token]; //late binding b/c not available when describe block is created
+      beforeEach(function () {
+        // late binding b/c not available when describe block is created
+        exp_token = exp[token];
       });
 
-      // TODO: figure out why these fail, error is "can.Map: Object does not exist thrown"
-      describe("when set for a page", function() {
-        beforeEach(function() {
-          display_prefs.makeObject(exp.path, exp_token).attr("foo", fooValue);
-          display_prefs.makeObject(exp.path, exp_token).attr("bar", barValue);
+      describe('when set for a page', function () {
+        beforeEach(function () {
+          display_prefs.makeObject(exp.path, exp_token).attr('foo', fooValue);
+          display_prefs.makeObject(exp.path, exp_token).attr('bar', barValue);
         });
-        afterEach(function() {
+
+        afterEach(function () {
           display_prefs.removeAttr(exp.path);
         });
 
-        it("returns the value set for the page", getTest);
+        it('returns the value set for the page', getTest);
       });
 
-      describe("when not set for a page", function() {
-        beforeEach(function() {
-          display_prefs.makeObject(exp_token, "unit_test").attr("foo", fooValue);
-          display_prefs.makeObject(exp_token, "unit_test").attr("bar", barValue);
+      describe('when not set for a page', function () {
+        beforeEach(function () {
+          display_prefs
+            .makeObject(exp_token, 'unit_test')
+            .attr('foo', fooValue);
+          display_prefs
+            .makeObject(exp_token, 'unit_test')
+            .attr('bar', barValue);
         });
-        afterEach(function() {
+        afterEach(function () {
           display_prefs.removeAttr(exp.path);
           display_prefs.removeAttr(exp_token);
         });
 
-        it("returns the value set for the page type default", getTest);
+        it('returns the value set for the page type default', getTest);
 
-        it("sets the default value as the page value", function() {
-          display_prefs[func]("unit_test", "foo");
-          var fooActual = display_prefs.attr([exp.path, exp_token, "foo"].join("."));
-          expect(fooActual.serialize ? fooActual.serialize() : fooActual)[fooMatcher](fooValue);
+        it('sets the default value as the page value', function () {
+          var fooActual;
+          display_prefs[func]('unit_test', 'foo');
+          fooActual = display_prefs.attr(
+            [exp.path, exp_token, 'foo'].join('.'));
+          expect(
+            fooActual.serialize ? fooActual.serialize() : fooActual
+          )[fooMatcher](fooValue);
         });
       });
     };
   }
 
-  describe("#getCollapsed", getSpecs("getCollapsed", "COLLAPSE", true, false));
+  describe(
+    '#getCollapsed',
+    getSpecs('getCollapsed', 'COLLAPSE', true, false));
 
-  describe("#getSorts", getSpecs("getSorts", "SORTS", ["baz, quux"], ["thud", "jeek"]));
-
+  describe(
+    '#getSorts',
+    getSpecs('getSorts', 'SORTS', ['baz, quux'], ['thud', 'jeek']));
 
   function setSpecs(func, token, fooValue, barValue) {
-    return function() {
+    return function () {
       var exp_token;
-      beforeEach(function() {
+
+      beforeEach(function () {
         exp_token = exp[token];
       });
-      afterEach(function() {
+
+      afterEach(function () {
         display_prefs.removeAttr(exp_token);
         display_prefs.removeAttr(exp.path);
       });
 
-      
-      it("sets the value for a widget", function() {
-        display_prefs[func]("this arg is ignored", "foo", fooValue);
-        var fooActual  = display_prefs.attr([exp.path, exp_token, "foo"].join("."));
-        expect(fooActual.serialize ? fooActual.serialize() : fooActual).toEqual(fooValue);
+      it('sets the value for a widget', function () {
+        var fooActual;
+        display_prefs[func]('this arg is ignored', 'foo', fooValue);
+        fooActual = display_prefs.attr([exp.path, exp_token, 'foo'].join('.'));
+        expect(fooActual.serialize ? fooActual.serialize() : fooActual)
+          .toEqual(fooValue);
       });
 
-      it("sets all values as a collection", function() {
-        display_prefs[func]("this arg is ignored", {"foo" : fooValue, "bar" : barValue});
-        var fooActual = display_prefs.attr([exp.path, exp_token, "foo"].join("."));
-        var barActual = display_prefs.attr([exp.path, exp_token, "bar"].join("."));
-        expect(fooActual.serialize ? fooActual.serialize() : fooActual).toEqual(fooValue);
-        expect(barActual.serialize ? barActual.serialize() : barActual).toEqual(barValue);
+      it('sets all values as a collection', function () {
+        var fooActual;
+        var barActual;
+
+        display_prefs[func](
+          'this arg is ignored',
+          {foo: fooValue, bar: barValue}
+        );
+
+        fooActual = display_prefs.attr([exp.path, exp_token, 'foo'].join('.'));
+        barActual = display_prefs.attr([exp.path, exp_token, 'bar'].join('.'));
+        expect(fooActual.serialize ? fooActual.serialize() : fooActual)
+          .toEqual(fooValue);
+        expect(barActual.serialize ? barActual.serialize() : barActual)
+          .toEqual(barValue);
       });
     };
   }
 
-  describe("#setSorts", setSpecs("setSorts", "SORTS", ["bar", "baz"], ["thud", "jeek"]));
+  describe(
+    '#setSorts',
+    setSpecs('setSorts', 'SORTS', ['bar', 'baz'], ['thud', 'jeek']));
 
-  describe("#getWidgetHeights", function() {});
+  describe(
+    '#getWidgetHeights',
+    function () {});
 
-  describe("#getWidgetHeight", getSpecs("getWidgetHeight", "HEIGHTS", 100, 200));
+  describe(
+    '#getWidgetHeight',
+    getSpecs('getWidgetHeight', 'HEIGHTS', 100, 200));
 
-  describe("#setWidgetHeight", setSpecs("setWidgetHeight", "HEIGHTS", 100, 200));
+  describe(
+    '#setWidgetHeight',
+    setSpecs('setWidgetHeight', 'HEIGHTS', 100, 200));
 
-  describe("#getColumnWidths", getSpecs("getColumnWidths", "COLUMNS", [6, 6], [8, 4]));
+  describe(
+    '#getColumnWidths',
+    getSpecs('getColumnWidths', 'COLUMNS', [6, 6], [8, 4]));
 
-  describe("#getColumnWidthsForSelector", function() {
-    it("calls getColumnWidths with the ID of the supplied element", function() {
-      var $foo = affix("#foo");
-      var $bar = affix("#bar");
+  describe('#getColumnWidthsForSelector', function () {
+    it('calls getColumnWidths with the ID of the supplied element',
+      function () {
+        var $foo = affix('#foo');
 
-      spyOn(display_prefs, "getColumnWidths");
+        spyOn(display_prefs, 'getColumnWidths');
 
-      display_prefs.getColumnWidthsForSelector("unit_test", $foo);
-      expect(display_prefs.getColumnWidths).toHaveBeenCalledWith("unit_test", "foo");
-    });
+        display_prefs.getColumnWidthsForSelector('unit_test', $foo);
+        expect(display_prefs.getColumnWidths)
+          .toHaveBeenCalledWith('unit_test', 'foo');
+      }
+    );
   });
 
-  describe("#setColumnWidths", setSpecs("setColumnWidths", "COLUMNS", [6,6], [4,8]));
+  describe(
+    '#setColumnWidths',
+    setSpecs('setColumnWidths', 'COLUMNS', [6, 6], [4, 8]));
 
-  describe("Set/Reset functions", function() {
-
-    describe("#resetPagePrefs", function() {
-
-      beforeEach(function() {
-        can.each([exp.COLUMNS, exp.HEIGHTS, exp.SORTS, exp.COLLAPSE], function(exp_token) {
-          display_prefs.makeObject(exp_token, "unit_test").attr("foo", "bar"); //page type defaults
-          display_prefs.makeObject(exp.path, exp_token).attr("foo", "baz"); //page custom settings
-        });
+  describe('Set/Reset functions', function () {
+    describe('#resetPagePrefs', function () {
+      beforeEach(function () {
+        can.each(
+          [exp.COLUMNS, exp.HEIGHTS, exp.SORTS, exp.COLLAPSE],
+          function (exp_token) {
+            display_prefs
+              .makeObject(exp_token, 'unit_test')
+              .attr('foo', 'bar'); // page type defaults
+            display_prefs
+              .makeObject(exp.path, exp_token)
+              .attr('foo', 'baz'); // page custom settings
+          }
+        );
       });
-      afterEach(function() {
+
+      afterEach(function () {
         display_prefs.removeAttr(exp.path);
-        can.each([exp.COLUMNS, exp.HEIGHTS, exp.SORTS, exp.COLLAPSE], function(exp_token) {
-          display_prefs.removeAttr(exp_token);
-        });
+        can.each(
+          [exp.COLUMNS, exp.HEIGHTS, exp.SORTS, exp.COLLAPSE],
+          function (exp_token) {
+            display_prefs.removeAttr(exp_token);
+          }
+        );
       });
 
-      it("sets the page layout to the default for the page type", function() {
+      it('sets the page layout to the default for the page type', function () {
         display_prefs.resetPagePrefs();
-        can.each(["getSorts", "getCollapsed", "getWidgetHeight", "getColumnWidths"], function(func) {
-          expect(display_prefs[func]("unit_test", "foo")).toBe("bar");
-        });
+        can.each(
+          ['getSorts', 'getCollapsed', 'getWidgetHeight', 'getColumnWidths'],
+          function (func) {
+            expect(display_prefs[func]('unit_test', 'foo')).toBe('bar');
+          }
+        );
       });
-
     });
 
-    describe("#setPageAsDefault", function() {
-      beforeEach(function() {
-        can.each([exp.COLUMNS, exp.HEIGHTS, exp.SORTS, exp.COLLAPSE], function(exp_token) {
-          display_prefs.makeObject(exp_token, "unit_test").attr("foo", "bar"); //page type defaults
-          display_prefs.makeObject(exp.path, exp_token).attr("foo", "baz"); //page custom settings
-        });
+    describe('#setPageAsDefault', function () {
+      beforeEach(function () {
+        can.each(
+          [exp.COLUMNS, exp.HEIGHTS, exp.SORTS, exp.COLLAPSE],
+          function (exp_token) {
+            display_prefs
+              .makeObject(exp_token, 'unit_test')
+              .attr('foo', 'bar'); // page type defaults
+            display_prefs
+              .makeObject(exp.path, exp_token)
+              .attr('foo', 'baz'); // page custom settings
+          }
+        );
       });
-      afterEach(function() {
+
+      afterEach(function () {
         display_prefs.removeAttr(exp.path);
-        can.each([exp.COLUMNS, exp.HEIGHTS, exp.SORTS, exp.COLLAPSE], function(exp_token) {
-          display_prefs.removeAttr(exp_token);
-        });
+        can.each(
+          [exp.COLUMNS, exp.HEIGHTS, exp.SORTS, exp.COLLAPSE],
+          function (exp_token) {
+            display_prefs.removeAttr(exp_token);
+          }
+        );
       });
 
-      it("sets the page layout to the default for the page type", function() {
-        display_prefs.setPageAsDefault("unit_test");
-        can.each([exp.COLUMNS, exp.HEIGHTS, exp.SORTS, exp.COLLAPSE], function(exp_token) {
-          expect(display_prefs.attr([exp_token, "unit_test", "foo"].join("."))).toBe("baz");
-        })
+      it('sets the page layout to the default for the page type', function () {
+        display_prefs.setPageAsDefault('unit_test');
+        can.each(
+          [exp.COLUMNS, exp.HEIGHTS, exp.SORTS, exp.COLLAPSE],
+          function (exp_token) {
+            expect(
+              display_prefs.attr([exp_token, 'unit_test', 'foo'].join('.'))
+            ).toBe('baz');
+          }
+        );
       });
 
-      it("keeps the page and the defaults separated", function() {
-        display_prefs.setPageAsDefault("unit_test");
-        can.each(["setColumnWidths", "setCollapsed", "setWidgetHeight", "setSorts"], function(func) {
-          display_prefs[func]("unit_test", "foo", "quux");
-        });
-        can.each([exp.COLUMNS, exp.HEIGHTS, exp.SORTS, exp.COLLAPSE], function(exp_token) {
-          expect(display_prefs.attr([exp_token, "unit_test", "foo"].join("."))).toBe("baz");
-        });
+      it('keeps the page and the defaults separated', function () {
+        display_prefs.setPageAsDefault('unit_test');
+        can.each(
+          ['setColumnWidths', 'setCollapsed', 'setWidgetHeight', 'setSorts'],
+          function (func) {
+            display_prefs[func]('unit_test', 'foo', 'quux');
+          }
+        );
+        can.each(
+          [exp.COLUMNS, exp.HEIGHTS, exp.SORTS, exp.COLLAPSE],
+          function (exp_token) {
+            expect(
+              display_prefs.attr([exp_token, 'unit_test', 'foo'].join('.'))
+            ).toBe('baz');
+          }
+        );
       });
-
     });
-
   });
 
-  describe("#findAll", function() {
-    var dp_noversion, dp2_outdated, dp3_current;
-    beforeEach(function() {
-      dp_noversion = new CMS.Models.DisplayPrefs({});
-      dp2_outdated = new CMS.Models.DisplayPrefs({ version : 1});
-      dp3_current = new CMS.Models.DisplayPrefs({ version : CMS.Models.DisplayPrefs.version });
+  describe('#findAll', function () {
+    var dp_noversion;
+    var dp2_outdated;
+    var dp3_current;
 
-      spyOn(can.Model.LocalStorage, "findAll").and.returnValue(new $.Deferred().resolve([dp_noversion, dp2_outdated, dp3_current]));
-      spyOn(dp_noversion, "destroy");
-      spyOn(dp2_outdated, "destroy");
-      spyOn(dp3_current, "destroy");
+    beforeEach(function () {
+      dp_noversion = new CMS.Models.DisplayPrefs({});
+      dp2_outdated = new CMS.Models.DisplayPrefs({version: 1});
+      dp3_current = new CMS.Models.DisplayPrefs({
+        version: CMS.Models.DisplayPrefs.version
+      });
+
+      spyOn(can.Model.LocalStorage, 'findAll').and.returnValue(
+        new $.Deferred().resolve([dp_noversion, dp2_outdated, dp3_current])
+      );
+      spyOn(dp_noversion, 'destroy');
+      spyOn(dp2_outdated, 'destroy');
+      spyOn(dp3_current, 'destroy');
     });
-    it("deletes any prefs that do not have a version set", function(done) {
-      var dfd = CMS.Models.DisplayPrefs.findAll().done(function(dps) {
+    it('deletes any prefs that do not have a version set', function (done) {
+      var dfd = CMS.Models.DisplayPrefs.findAll().done(function (dps) {
         expect(dps).not.toContain(dp_noversion);
         expect(dp_noversion.destroy).toHaveBeenCalled();
       });
-        
-      waitsFor(function() { //sanity check --ensure deferred resolves/rejects
-        return dfd.state() !== "pending";
+
+      // sanity check --ensure deferred resolves/rejects
+      waitsFor(function () {
+        return dfd.state() !== 'pending';
       }, done);
     });
-    it("deletes any prefs that have an out of date version", function() {
-      CMS.Models.DisplayPrefs.findAll().done(function(dps) {
+    it('deletes any prefs that have an out of date version', function () {
+      CMS.Models.DisplayPrefs.findAll().done(function (dps) {
         expect(dps).not.toContain(dp2_outdated);
         expect(dp2_outdated.destroy).toHaveBeenCalled();
       });
     });
-    it("retains any prefs that do not have a version set", function() {
-      CMS.Models.DisplayPrefs.findAll().done(function(dps) {
+    it('retains any prefs that do not have a version set', function () {
+      CMS.Models.DisplayPrefs.findAll().done(function (dps) {
         expect(dps).toContain(dp3_current);
         expect(dp3_current.destroy).not.toHaveBeenCalled();
       });
     });
   });
 
-  describe("#findOne", function() {
-    var dp_noversion, dp2_outdated, dp3_current;
-    beforeEach(function() {
+  describe('#findOne', function () {
+    var dp_noversion;
+    var dp2_outdated;
+    var dp3_current;
+
+    beforeEach(function () {
       dp_noversion = new CMS.Models.DisplayPrefs({});
-      dp2_outdated = new CMS.Models.DisplayPrefs({ version : 1});
-      dp3_current = new CMS.Models.DisplayPrefs({ version : CMS.Models.DisplayPrefs.version });
+      dp2_outdated = new CMS.Models.DisplayPrefs({version: 1});
+      dp3_current = new CMS.Models.DisplayPrefs({
+        version: CMS.Models.DisplayPrefs.version
+      });
     });
-    it("404s if the display pref does not have a version set", function(done) {
-      spyOn(can.Model.LocalStorage, "findOne").and.returnValue(new $.Deferred().resolve(dp_noversion));
-      spyOn(dp_noversion, "destroy");
-      var dfd = CMS.Models.DisplayPrefs.findOne().done(function(dps) {
-        fail("Should not have resolved findOne for the unversioned display pref");
-      }).fail(function(pseudoxhr) {
+
+    it('404s if the display pref does not have a version set', function (done) {
+      var dfd;
+      spyOn(can.Model.LocalStorage, 'findOne')
+        .and.returnValue(new $.Deferred().resolve(dp_noversion));
+      spyOn(dp_noversion, 'destroy');
+      dfd = CMS.Models.DisplayPrefs.findOne().done(function (dps) {
+        fail(
+          'Should not have resolved findOne for the unversioned display pref');
+      }).fail(function (pseudoxhr) {
         expect(pseudoxhr.status).toBe(404);
         expect(dp_noversion.destroy).toHaveBeenCalled();
       });
-      waitsFor(function() { //sanity check --ensure deferred resolves/rejects
-        return dfd.state() !== "pending";
+
+      // sanity check --ensure deferred resolves/rejects
+      waitsFor(function () {
+        return dfd.state() !== 'pending';
       }, done);
     });
-    it("404s if the display pref has an out of date version", function() {
-      spyOn(can.Model.LocalStorage, "findOne").and.returnValue(new $.Deferred().resolve(dp2_outdated));
-      spyOn(dp2_outdated, "destroy");
-      CMS.Models.DisplayPrefs.findOne().done(function(dps) {
-        fail("Should not have resolved findOne for the outdated display pref");
-      }).fail(function(pseudoxhr) {
+
+    it('404s if the display pref has an out of date version', function () {
+      spyOn(can.Model.LocalStorage, 'findOne')
+        .and.returnValue(new $.Deferred().resolve(dp2_outdated));
+      spyOn(dp2_outdated, 'destroy');
+      CMS.Models.DisplayPrefs.findOne().done(function (dps) {
+        fail('Should not have resolved findOne for the outdated display pref');
+      }).fail(function (pseudoxhr) {
         expect(pseudoxhr.status).toBe(404);
         expect(dp2_outdated.destroy).toHaveBeenCalled();
       });
     });
-    it("retains any prefs that do not have a version set", function() {
-      spyOn(can.Model.LocalStorage, "findOne").and.returnValue(new $.Deferred().resolve(dp3_current));
-      spyOn(dp3_current, "destroy");
-      CMS.Models.DisplayPrefs.findOne().done(function(dps) {
+
+    it('retains any prefs that do not have a version set', function () {
+      spyOn(can.Model.LocalStorage, 'findOne')
+        .and.returnValue(new $.Deferred().resolve(dp3_current));
+      spyOn(dp3_current, 'destroy');
+      CMS.Models.DisplayPrefs.findOne().done(function (dps) {
         expect(dp3_current.destroy).not.toHaveBeenCalled();
-      }).fail(function() {
-        fail("Should have resolved on findOne for the current display pref");
+      }).fail(function () {
+        fail('Should have resolved on findOne for the current display pref');
       });
     });
   });
-
 });

--- a/src/ggrc/assets/js_specs/models/local_storage_spec.js
+++ b/src/ggrc/assets/js_specs/models/local_storage_spec.js
@@ -5,36 +5,35 @@
     Maintained By: brad@reciprocitylabs.com
 */
 
-//= require models/local_storage
+// = require models/local_storage
 
+describe('can.Model.LocalStorage', function () {
+  var model1 = {id: 1, foo: 'bar'};
+  var model2 = {id: 2, foo: 'baz'};
+  var SpecModel;
 
-describe("can.Model.LocalStorage", function() {
-  
-  //run-once setup
-  beforeAll(function() {
-    can.Model.LocalStorage("SpecModel");
+  // run-once setup
+  beforeAll(function () {
+    can.Model.LocalStorage('SpecModel');
+    SpecModel = window.SpecModel;
   });
 
-  var model1 = { "id" : 1, "foo" : "bar" };
-  var model2 = { "id" : 2, "foo" : "baz" };
-
-  beforeEach(function() {
-    window.localStorage.setItem("spec_model:ids", "[1, 2]");
-    window.localStorage.setItem("spec_model:1", JSON.stringify(model1));
-    window.localStorage.setItem("spec_model:2", JSON.stringify(model2));
+  beforeEach(function () {
+    window.localStorage.setItem('spec_model:ids', '[1, 2]');
+    window.localStorage.setItem('spec_model:1', JSON.stringify(model1));
+    window.localStorage.setItem('spec_model:2', JSON.stringify(model2));
   });
 
-  afterEach(function() {
-    window.localStorage.removeItem("spec_model:ids");
-    window.localStorage.removeItem("spec_model:1");
-    window.localStorage.removeItem("spec_model:2");
+  afterEach(function () {
+    window.localStorage.removeItem('spec_model:ids');
+    window.localStorage.removeItem('spec_model:1');
+    window.localStorage.removeItem('spec_model:2');
   });
-  describe("::findAll", function() {
 
-
-    it("returns all model instnances with no arguments", function() {
+  describe('::findAll', function () {
+    it('returns all model instnances with no arguments', function () {
       var success = false;
-      SpecModel.findAll().done(function(list) {
+      SpecModel.findAll().done(function (list) {
         expect(list.length).toBe(2);
         expect(list instanceof can.Model.List).toBeTruthy();
         expect(list[0] instanceof SpecModel).toBeTruthy();
@@ -45,9 +44,9 @@ describe("can.Model.LocalStorage", function() {
       expect(success).toBe(true);
     });
 
-    it("filters by id parameter", function() {
+    it('filters by id parameter', function () {
       var success = false;
-      SpecModel.findAll({id : 1}).done(function(list) {
+      SpecModel.findAll({id: 1}).done(function (list) {
         expect(list.length).toBe(1);
         expect(list[0].serialize()).toEqual(model1);
         success = true;
@@ -55,9 +54,9 @@ describe("can.Model.LocalStorage", function() {
       expect(success).toBe(true);
     });
 
-    it("filters by other parameters", function() {
+    it('filters by other parameters', function () {
       var success = false;
-      SpecModel.findAll({foo : "bar"}).done(function(list) {
+      SpecModel.findAll({foo: 'bar'}).done(function (list) {
         expect(list.length).toBe(1);
         expect(list[0].serialize()).toEqual(model1);
         success = true;
@@ -65,23 +64,21 @@ describe("can.Model.LocalStorage", function() {
       expect(success).toBe(true);
     });
 
-    it("returns an empty list with no matches", function() {
+    it('returns an empty list with no matches', function () {
       var success = false;
-      SpecModel.findAll({quux : "thud"}).done(function(list) {
+      SpecModel.findAll({quux: 'thud'}).done(function (list) {
         expect(list instanceof can.Model.List).toBeTruthy();
         expect(list.length).toBe(0);
         success = true;
       });
       expect(success).toBe(true);
     });
-
   });
 
-  describe("::findOne", function() {
-
-    it("returns a single model instance by id", function() {
+  describe('::findOne', function () {
+    it('returns a single model instance by id', function () {
       var success = false;
-      SpecModel.findOne({id : 1}).done(function(item) {
+      SpecModel.findOne({id: 1}).done(function (item) {
         expect(item instanceof SpecModel).toBeTruthy();
         expect(item.serialize()).toEqual(model1);
         success = true;
@@ -89,91 +86,100 @@ describe("can.Model.LocalStorage", function() {
       expect(success).toBe(true);
     });
 
-    it("fails with status 404 when the id is not found", function(done) {
+    it('fails with status 404 when the id is not found', function (done) {
       var failure = false;
-      SpecModel.findOne({id : 3}).fail(function(xhr) {
+      SpecModel.findOne({id: 3}).fail(function (xhr) {
         expect(xhr.status).toBe(404);
         failure = true;
       });
-      waitsFor(function() {
+      waitsFor(function () {
         return failure;
       }, done);
     });
   });
 
-  describe("::create", function() {
-    beforeEach(function() {
-      window.localStorage.removeItem("spec_model:ids");
-      window.localStorage.removeItem("spec_model:1");
-      window.localStorage.removeItem("spec_model:2");
+  describe('::create', function () {
+    beforeEach(function () {
+      window.localStorage.removeItem('spec_model:ids');
+      window.localStorage.removeItem('spec_model:1');
+      window.localStorage.removeItem('spec_model:2');
     });
 
-    it("creates and registers a model", function() {
+    it('creates and registers a model', function () {
       var success = false;
-      new SpecModel({ foo : model1.foo }).save().done(function(item) {
+      new SpecModel({foo: model1.foo}).save().done(function (item) {
+        var ids;
         expect(item.id).toBeDefined();
         expect(item.foo).toEqual(model1.foo);
 
-        var ids = JSON.parse(window.localStorage.getItem("spec_model:ids"));
+        ids = JSON.parse(window.localStorage.getItem('spec_model:ids'));
         expect(ids.length).toEqual(1);
-        expect(window.localStorage.getItem("spec_model:" + ids[0])).toBeDefined();
+        expect(
+          window.localStorage.getItem('spec_model:' + ids[0])).toBeDefined();
         success = true;
       });
       expect(success).toBe(true);
     });
 
-    it("creates a model with an appropriate ID when the array of IDs is empty", function() {
-      var success = false;
-      window.localStorage.setItem("spec_model:ids", "[]");
-      new SpecModel({ foo : model1.foo }).save().done(function(item) {
-        expect(item.id + 1).not.toBe(item.id); //not infinity, not NaN
-        expect(item.foo).toEqual(model1.foo);
+    it('creates a model with an appropriate ID when the array of IDs is empty',
+      function () {
+        var success = false;
+        window.localStorage.setItem('spec_model:ids', '[]');
+        new SpecModel({foo: model1.foo}).save().done(function (item) {
+          var ids;
+          expect(item.id + 1).not.toBe(item.id); // not infinity, not NaN
+          expect(item.foo).toEqual(model1.foo);
 
-        var ids = JSON.parse(window.localStorage.getItem("spec_model:ids"));
-        expect(ids.length).toEqual(1);
-        expect(window.localStorage.getItem("spec_model:" + ids[0])).toBeDefined();
-        success = true;
-      });
-      window.localStorage.removeItem("spec_model:-Infinity"); //the problem key
-      expect(success).toBe(true);
-    });
+          ids = JSON.parse(window.localStorage.getItem('spec_model:ids'));
+          expect(ids.length).toEqual(1);
+          expect(
+            window.localStorage.getItem('spec_model:' + ids[0])) .toBeDefined();
+          success = true;
+        });
 
+        // the problem key
+        window.localStorage.removeItem('spec_model:-Infinity');
+
+        expect(success).toBe(true);
+      }
+    );
   });
 
-  describe("::update", function() {
-
-    it("updates model instance by id", function() {
+  describe('::update', function () {
+    it('updates model instance by id', function () {
       var success = false;
-      var m = new SpecModel(model1);
-      m.attr("quux", "thud").save().done(function(item) {
+      var model = new SpecModel(model1);
+      model.attr('quux', 'thud').save().done(function (item) {
         expect(item instanceof SpecModel).toBeTruthy();
-        expect(JSON.parse(window.localStorage.getItem("spec_model:1"))).toEqual(can.extend({quux : "thud"}, model1));
+        expect(JSON.parse(window.localStorage.getItem('spec_model:1')))
+          .toEqual(can.extend({quux: 'thud'}, model1));
         success = true;
       });
       expect(success).toBe(true);
     });
 
-    it("fails with status 404 when the id is not found", function(done) {
+    it('fails with status 404 when the id is not found', function (done) {
       var failure = false;
-      new SpecModel().attr({id : 3}).save().fail(function(xhr) {
+      new SpecModel().attr({id: 3}).save().fail(function (xhr) {
         expect(xhr.status).toBe(404);
         failure = true;
       });
-      waitsFor(function() {
+      waitsFor(function () {
         return failure;
       }, done);
     });
   });
 
-
-  describe("::destroy", function() {
-
-    it("deletes model instance by id", function() {
+  describe('::destroy', function () {
+    it('deletes model instance by id', function () {
       var success = false;
-      new SpecModel(model1).destroy().done(function(item) {
+
+      new SpecModel(model1).destroy().done(function (item) {
+        var ids;
         expect(item.serialize()).toEqual(model1);
-        expect(JSON.parse(window.localStorage.getItem("spec_model:1"))).toBeNull();
-        var ids = JSON.parse(window.localStorage.getItem("spec_model:ids"));
+        expect(
+          JSON.parse(window.localStorage.getItem('spec_model:1'))).toBeNull();
+        ids = JSON.parse(window.localStorage.getItem('spec_model:ids'));
         expect(ids.length).toBe(1);
         expect(ids[0]).not.toEqual(item.id);
         success = true;
@@ -181,17 +187,15 @@ describe("can.Model.LocalStorage", function() {
       expect(success).toBe(true);
     });
 
-    it("fails with status 404 when the id is not found", function(done) {
+    it('fails with status 404 when the id is not found', function (done) {
       var failure = false;
-      new SpecModel().attr({id : 3}).destroy().fail(function(xhr) {
+      new SpecModel().attr({id: 3}).destroy().fail(function (xhr) {
         expect(xhr.status).toBe(404);
         failure = true;
       });
-      waitsFor(function() {
+      waitsFor(function () {
         return failure;
       }, done);
     });
-
   });
-
 });

--- a/src/ggrc/assets/js_specs/models/mappers_spec.js
+++ b/src/ggrc/assets/js_specs/models/mappers_spec.js
@@ -5,292 +5,305 @@
     Maintained By: brad@reciprocitylabs.com
 */
 
-describe("mappers", function() {
-  
+/* eslint max-nested-callbacks: 0 */
+
+describe('mappers', function () {
   var LL;
-  beforeEach(function() {
+
+  beforeEach(function () {
     LL = GGRC.ListLoaders;
-    if(!GGRC.Jasmine || !GGRC.Jasmine.MockModel) {
-      can.Model.Cacheable("GGRC.Jasmine.MockModel", {}, {});
+    if (!GGRC.Jasmine || !GGRC.Jasmine.MockModel) {
+      can.Model.Cacheable('GGRC.Jasmine.MockModel', {}, {});
     }
   });
 
-  describe("ListBinding", function() {
-
-    describe("#init", function() {
-
-      it("sets instance and loader to supplied arguments", function() {
+  describe('ListBinding', function () {
+    describe('#init', function () {
+      it('sets instance and loader to supplied arguments', function () {
         var lb = new LL.ListBinding(1, 2);
         expect(lb.instance).toBe(1);
         expect(lb.loader).toBe(2);
       });
 
-      it("creates a new observable list", function() {
+      it('creates a new observable list', function () {
         expect(new LL.ListBinding().list).toEqual(jasmine.any(can.List));
       });
-
     });
 
-    describe("#refresh_stubs", function() {
-
-      it("calls refresh_stubs on its loader", function() {
+    describe('#refresh_stubs', function () {
+      it('calls refresh_stubs on its loader', function () {
         var loader = jasmine.createSpyObj('loader', ['refresh_stubs']);
         var binding = new LL.ListBinding({}, loader);
         binding.refresh_stubs();
         expect(loader.refresh_stubs).toHaveBeenCalledWith(binding);
       });
-
     });
 
-    describe("#refresh_instances", function() {
-
-      it("calls refresh_instances on its loader", function() {
+    describe('#refresh_instances', function () {
+      it('calls refresh_instances on its loader', function () {
         var loader = jasmine.createSpyObj('loader', ['refresh_instances']);
         var binding = new LL.ListBinding({}, loader);
         binding.refresh_instances();
         expect(loader.refresh_instances).toHaveBeenCalledWith(binding);
       });
-
     });
 
-    describe("#refresh_count", function() {
-
+    describe('#refresh_count', function () {
       var binding;
-      beforeEach(function() {
+
+      beforeEach(function () {
         binding = new LL.ListBinding({}, {});
       });
 
-      it("calls refresh_stubs on itself", function() {
-        spyOn(binding, "refresh_stubs").and.returnValue($.when());
+      it('calls refresh_stubs on itself', function () {
+        spyOn(binding, 'refresh_stubs').and.returnValue($.when());
         binding.refresh_count();
         expect(binding.refresh_stubs).toHaveBeenCalledWith();
       });
 
-      it("returns a deferred that resolves to a compute", function(done) {
+      it('returns a deferred that resolves to a compute', function (done) {
         var deferred;
-        spyOn(binding, "refresh_stubs").and.returnValue($.when());
+        spyOn(binding, 'refresh_stubs').and.returnValue($.when());
         deferred = binding.refresh_count();
-        expect(typeof deferred.then).toBe("function");
-        deferred.then(function(value) {
+        expect(typeof deferred.then).toBe('function');
+        deferred.then(function (value) {
           expect(value.isComputed).toBeTruthy();
           done();
-        }, function() {
-          fail("Deferred returned from refresh_count was rejected");
+        }, function () {
+          fail('Deferred returned from refresh_count was rejected');
         });
       });
 
-      it("...and the compute returns the list length", function(done) {
+      it('...and the compute returns the list length', function (done) {
         var deferred;
         binding.list.push(1, 2, 3);
-        spyOn(binding, "refresh_stubs").and.returnValue($.when());
+        spyOn(binding, 'refresh_stubs').and.returnValue($.when());
         deferred = binding.refresh_count();
-        deferred.then(function(value) {
+        deferred.then(function (value) {
           expect(value()).toBe(3);
           done();
-        }, function() {
-          fail("Deferred returned from refresh_count was rejected");
+        }, function () {
+          fail('Deferred returned from refresh_count was rejected');
         });
       });
-
     });
 
-    describe("#refresh_list", function() {
+    describe('#refresh_list', function () {
+      var binding;
+      var loader;
+      var other_binding;
 
-      var binding, loader, other_binding;
-      beforeEach(function() {
-        other_binding = jasmine.createSpyObj('other_binding', ['refresh_instances']);
+      beforeEach(function () {
+        other_binding = jasmine.createSpyObj(
+          'other_binding', ['refresh_instances']);
         other_binding.refresh_instances.and.returnValue($.when());
-        loader = jasmine.createSpyObj('loader', ['attach', 'refresh_instances']);
+        loader = jasmine.createSpyObj(
+          'loader', ['attach', 'refresh_instances']);
         loader.refresh_instances.and.returnValue($.when());
         loader.attach.and.returnValue(other_binding);
-        spyOn(LL.ReifyingListLoader, "newInstance").and.returnValue(loader);
+        spyOn(LL.ReifyingListLoader, 'newInstance').and.returnValue(loader);
         binding = new LL.ListBinding({}, {});
-        spyOn(binding, "refresh_instances").and.returnValue($.when());
+        spyOn(binding, 'refresh_instances').and.returnValue($.when());
       });
 
-      it("attaches its instance to a new ReifyingListLoader", function() {
+      it('attaches its instance to a new ReifyingListLoader', function () {
         binding.refresh_list();
-        expect(LL.ReifyingListLoader.newInstance).toHaveBeenCalledWith(binding);
+        expect(LL.ReifyingListLoader.newInstance)
+          .toHaveBeenCalledWith(binding);
         expect(loader.attach).toHaveBeenCalledWith(binding.instance);
       });
 
-      it("sets the name of the ReifyingListLoader's ListBinding to its own name plus \"_instances\"", function() {
-        binding.name = "foo";
-        binding.refresh_list();
-        expect(other_binding.name).toBe("foo_instances");
-      });
+      it('sets the name of the ReifyingListLoader\'s ListBinding to its ' +
+        'own name plus "_instances"',
+        function () {
+          binding.name = 'foo';
+          binding.refresh_list();
+          expect(other_binding.name).toBe('foo_instances');
+        }
+      );
 
-      it("refreshes instances on the new binding", function() {
+      it('refreshes instances on the new binding', function () {
         binding.refresh_list();
         expect(other_binding.refresh_instances).toHaveBeenCalledWith(binding);
       });
 
-      it("refreshes its own instances after refreshing the new binding's instances", function(done) {
-        var dfd = binding.refresh_list();
-        dfd.then(function() {
-          expect(binding.refresh_instances).toHaveBeenCalledWith();
-          done();
-        }, function() {
-          fail("deferred was rejected in refresh_instances");
-        });
-      });
+      it('refreshes its own instances after refreshing the new binding\'s ' +
+        'instances',
+        function (done) {
+          var dfd = binding.refresh_list();
+          dfd.then(function () {
+            expect(binding.refresh_instances).toHaveBeenCalledWith();
+            done();
+          }, function () {
+            fail('deferred was rejected in refresh_instances');
+          });
+        }
+      );
     });
 
-    describe("#refresh_instance", function() {
-
-      it("enqueues the instance in a triggered RefreshQueue", function() {
-        spyOn(RefreshQueue.prototype, "enqueue");
-        spyOn(RefreshQueue.prototype, "trigger");
+    describe('#refresh_instance', function () {
+      it('enqueues the instance in a triggered RefreshQueue', function () {
+        spyOn(RefreshQueue.prototype, 'enqueue');
+        spyOn(RefreshQueue.prototype, 'trigger');
         new LL.ListBinding(1, {}).refresh_instance();
         expect(RefreshQueue.prototype.enqueue).toHaveBeenCalledWith(1);
         expect(RefreshQueue.prototype.trigger).toHaveBeenCalledWith();
       });
 
-      it("returns the deferred from the refresh queue", function() {
+      it('returns the deferred from the refresh queue', function () {
         var dfd = $.when();
-        spyOn(RefreshQueue.prototype, "enqueue");
-        spyOn(RefreshQueue.prototype, "trigger").and.returnValue(dfd);
+        spyOn(RefreshQueue.prototype, 'enqueue');
+        spyOn(RefreshQueue.prototype, 'trigger').and.returnValue(dfd);
         expect(new LL.ListBinding(1, {}).refresh_instance()).toBe(dfd);
       });
-
     });
-
   });
 
-  describe("MappingResult", function() {
-
-    describe("#init", function() {
-
-      it("sets the named properties to the positional parameters", function() {
+  describe('MappingResult', function () {
+    describe('#init', function () {
+      it('sets the named properties to the positional parameters', function () {
         var mr;
-        spyOn(LL.MappingResult.prototype, "_make_mappings").and.callFake(function(mapping_name) {
-          expect(mapping_name).toBe("mappings");
-          return "_mapping";
-        });
-        mr = new LL.MappingResult("instance", "mappings", "binding");
+        spyOn(LL.MappingResult.prototype, '_make_mappings')
+          .and.callFake(function (mapping_name) {
+            expect(mapping_name).toBe('mappings');
+            return '_mapping';
+          }
+        );
 
-        expect(mr.instance).toBe("instance");
-        expect(mr.binding).toBe("binding");
-        expect(mr.mappings).toBe("_mapping");
-        expect(LL.MappingResult.prototype._make_mappings).toHaveBeenCalledWith("mappings");
+        mr = new LL.MappingResult('instance', 'mappings', 'binding');
+
+        expect(mr.instance).toBe('instance');
+        expect(mr.binding).toBe('binding');
+        expect(mr.mappings).toBe('_mapping');
+        expect(LL.MappingResult.prototype._make_mappings)
+          .toHaveBeenCalledWith('mappings');
       });
 
-      it("sets the named properties to the object properties if called with an object", function() {
-        var mr;
-        spyOn(LL.MappingResult.prototype, "_make_mappings").and.callFake(function(mapping_name) {
-          expect(mapping_name).toBe("mappings");
-          return "_mapping";
-        });
-        mr = new LL.MappingResult({instance: "instance", mappings: "mappings", binding: "binding"});
+      it('sets the named properties to the object properties if called with ' +
+        'an object',
+        function () {
+          var mr;
 
-        expect(mr.instance).toBe("instance");
-        expect(mr.binding).toBe("binding");
-        expect(mr.mappings).toBe("_mapping");
-        expect(LL.MappingResult.prototype._make_mappings).toHaveBeenCalledWith("mappings");
-      });
+          spyOn(LL.MappingResult.prototype, '_make_mappings')
+            .and.callFake(function (mapping_name) {
+              expect(mapping_name).toBe('mappings');
+              return '_mapping';
+            }
+          );
 
+          mr = new LL.MappingResult({
+            instance: 'instance',
+            mappings: 'mappings',
+            binding: 'binding'
+          });
+
+          expect(mr.instance).toBe('instance');
+          expect(mr.binding).toBe('binding');
+          expect(mr.mappings).toBe('_mapping');
+          expect(LL.MappingResult.prototype._make_mappings)
+            .toHaveBeenCalledWith('mappings');
+        }
+      );
     });
 
-    describe("#_make_mappings", function() {
-      it("converts all elements of the supplied array to mapping results", function() {
-        var mr = new LL.MappingResult("foo", ["bar"], "baz");
-        expect(mr._make_mappings(["baz", "quux", mr]))
-          .toEqual([
-            jasmine.any(LL.MappingResult),
-            jasmine.any(LL.MappingResult),
-            mr
-          ]);
-      });
+    describe('#_make_mappings', function () {
+      it('converts all elements of the supplied array to mapping results',
+        function () {
+          var mr = new LL.MappingResult('foo', ['bar'], 'baz');
+          expect(mr._make_mappings(['baz', 'quux', mr]))
+            .toEqual([
+              jasmine.any(LL.MappingResult),
+              jasmine.any(LL.MappingResult),
+              mr
+            ]);
+        }
+      );
     });
 
-    describe("#get_bindings", function() {
-
-      it("finds all depth-1 bindings touched by walk_instances", function() {
-        var mr = new LL.MappingResult("foo", ["bar"], "baz");
+    describe('#get_bindings', function () {
+      it('finds all depth-1 bindings touched by walk_instances', function () {
+        var mr = new LL.MappingResult('foo', ['bar'], 'baz');
         var phony_binding = {};
-        var phony_result = { binding: phony_binding };
-        spyOn(mr, "walk_instances").and.callFake(function(fn) {
+        var phony_result = {binding: phony_binding};
+        spyOn(mr, 'walk_instances').and.callFake(function (fn) {
           fn({}, phony_result, 1);
-          fn({}, { binding: {} }, 2);
+          fn({}, {binding: {}}, 2);
         });
         expect(mr.get_bindings()).toEqual([phony_binding]);
       });
-
     });
 
-    describe("#bindings_compute", function() {
-
+    describe('#bindings_compute', function () {
       var mr;
-      beforeEach(function() {
-        mr = new LL.MappingResult("foo", ["bar"], "baz");
-      })
 
-      it("returns the saved compute if it exists.", function() {
+      beforeEach(function () {
+        mr = new LL.MappingResult('foo', ['bar'], 'baz');
+      });
+
+      it('returns the saved compute if it exists.', function () {
         var compute = can.compute();
         mr._bindings_compute = compute;
         expect(mr.bindings_compute()).toBe(compute);
       });
 
-      it("calls get_bindings_compute if no saved compute exists.", function() {
-        spyOn(mr, "get_bindings_compute");
+      it('calls get_bindings_compute if no saved compute exists.', function () {
+        spyOn(mr, 'get_bindings_compute');
         mr.bindings_compute();
         expect(mr.get_bindings_compute).toHaveBeenCalled();
       });
-
     });
 
-    describe("#get_bindings_compute", function() {
-
+    describe('#get_bindings_compute', function () {
       var mr;
-      beforeEach(function() {
-        mr = new LL.MappingResult("foo", ["bar"], "baz");
+
+      beforeEach(function () {
+        mr = new LL.MappingResult('foo', ['bar'], 'baz');
       });
 
-      it("returns a can.compute", function() {
+      it('returns a can.compute', function () {
         var result = mr.get_bindings_compute();
-        expect(typeof result).toBe("function");
+        expect(typeof result).toBe('function');
         expect(result.isComputed).toBe(true);
       });
 
-      describe("returned compute", function() {
-        it("returns the bindings", function() {
-          var result, phony_binding = {};
-          spyOn(mr, "get_bindings").and.returnValue([phony_binding]);
+      describe('returned compute', function () {
+        it('returns the bindings', function () {
+          var result;
+          var phony_binding = {};
+          spyOn(mr, 'get_bindings').and.returnValue([phony_binding]);
           result = (mr.get_bindings_compute())();
           expect(result).toEqual([phony_binding]);
         });
 
-        it("watches the observe trigger", function() {
-          spyOn(mr, "watch_observe_trigger");
+        it('watches the observe trigger', function () {
+          spyOn(mr, 'watch_observe_trigger');
           (mr.get_bindings_compute())();
           expect(mr.watch_observe_trigger).toHaveBeenCalled();
         });
       });
-
     });
 
-    describe("#get_mappings", function() {
-
-      it("calls walk_instances", function() {
-        var mr = new LL.MappingResult("foo", ["bar"], "baz");
-        spyOn(mr, "walk_instances");
+    describe('#get_mappings', function () {
+      it('calls walk_instances', function () {
+        var mr = new LL.MappingResult('foo', ['bar'], 'baz');
+        spyOn(mr, 'walk_instances');
         mr.get_mappings();
         expect(mr.walk_instances).toHaveBeenCalled();
       });
 
-      it("gets all instances where depth is 1", function() {
-        var mr = new LL.MappingResult("foo", ["bar"], "baz");
-        spyOn(mr, "walk_instances").and.callFake(function(fn) {
-          fn("foo", {}, 1);
-          fn("bar", {}, 2);
+      it('gets all instances where depth is 1', function () {
+        var mr = new LL.MappingResult('foo', ['bar'], 'baz');
+        spyOn(mr, 'walk_instances').and.callFake(function (fn) {
+          fn('foo', {}, 1);
+          fn('bar', {}, 2);
         });
-        expect(mr.get_mappings()).toEqual(["foo"]);
+        expect(mr.get_mappings()).toEqual(['foo']);
       });
 
-      it("adds self for depth=1 and instance=true", function() {
+      it('adds self for depth=1 and instance=true', function () {
         var instance = {};
-        var mr = new LL.MappingResult(instance, ["bar"], "baz");
-        spyOn(mr, "walk_instances").and.callFake(function(fn) {
+        var mr = new LL.MappingResult(instance, ['bar'], 'baz');
+        spyOn(mr, 'walk_instances').and.callFake(function (fn) {
           fn(true, {}, 1);
         });
         expect(mr.get_mappings().length).toBe(1);
@@ -298,630 +311,777 @@ describe("mappers", function() {
       });
     });
 
-    describe("#mappings_compute", function() {
-
+    describe('#mappings_compute', function () {
       var mr;
-      beforeEach(function() {
-        mr = new LL.MappingResult("foo", ["bar"], "baz");
-      })
 
-      it("returns the saved compute if it exists.", function() {
+      beforeEach(function () {
+        mr = new LL.MappingResult('foo', ['bar'], 'baz');
+      });
+
+      it('returns the saved compute if it exists.', function () {
         var compute = can.compute();
         mr._mappings_compute = compute;
         expect(mr.mappings_compute()).toBe(compute);
       });
 
-      it("calls get_mappings_compute if no saved compute exists.", function() {
-        spyOn(mr, "get_mappings_compute");
+      it('calls get_mappings_compute if no saved compute exists.', function () {
+        spyOn(mr, 'get_mappings_compute');
         mr.mappings_compute();
         expect(mr.get_mappings_compute).toHaveBeenCalled();
       });
-
     });
 
-    describe("#get_mappings_compute", function() {
-
+    describe('#get_mappings_compute', function () {
       var mr;
-      beforeEach(function() {
-        mr = new LL.MappingResult("foo", ["bar"], "baz");
+
+      beforeEach(function () {
+        mr = new LL.MappingResult('foo', ['bar'], 'baz');
       });
 
-      it("returns a can.compute", function() {
+      it('returns a can.compute', function () {
         var result = mr.get_mappings_compute();
-        expect(typeof result).toBe("function");
+        expect(typeof result).toBe('function');
         expect(result.isComputed).toBe(true);
       });
 
-      describe("returned compute", function() {
-        it("returns the mappings", function() {
-          var result, phony_binding = {};
-          spyOn(mr, "get_mappings").and.returnValue([phony_binding]);
+      describe('returned compute', function () {
+        it('returns the mappings', function () {
+          var result;
+          var phony_binding = {};
+          spyOn(mr, 'get_mappings').and.returnValue([phony_binding]);
           result = (mr.get_mappings_compute())();
           expect(result).toEqual([phony_binding]);
         });
 
-        it("watches the observe trigger", function() {
-          spyOn(mr, "watch_observe_trigger");
+        it('watches the observe trigger', function () {
+          spyOn(mr, 'watch_observe_trigger');
           (mr.get_mappings_compute())();
           expect(mr.watch_observe_trigger).toHaveBeenCalled();
         });
       });
-
     });
 
-    describe("#walk_instances", function() {
-
-      describe("when last_instance is not this MappingResult's instance", function() {
-        it("calls the function on itself", function() {
-          var sanity_check = false;
-          var mr = new LL.MappingResult("foo", [], "bar");
-          mr.walk_instances(function(instance, _result, depth) {
-            expect(instance).toBe("foo");
-            expect(depth).toBe(0);
-            sanity_check = true;
-          }, "bar", 0);
-          expect(sanity_check).toBe(true);
-        });
-
-        describe("when mappings length is greater than zero", function() {
-          it("calls walk_instances on each mapping with depth incremented", function() {
-            var fake_result = jasmine.createSpyObj("fake_result", ['walk_instances']);
-            spyOn(LL.MappingResult.prototype, "_make_mappings").and.returnValue([fake_result]);
-            var mr = new LL.MappingResult("foo", [], "bar");
-            var func = function() {};
-            mr.walk_instances(func, "bar", 0);
-            expect(fake_result.walk_instances).toHaveBeenCalledWith(func, "foo", 1);
+    describe('#walk_instances', function () {
+      describe('when last_instance is not this MappingResult\'s instance',
+        function () {
+          it('calls the function on itself', function () {
+            var sanity_check = false;
+            var mr = new LL.MappingResult('foo', [], 'bar');
+            mr.walk_instances(function (instance, _result, depth) {
+              expect(instance).toBe('foo');
+              expect(depth).toBe(0);
+              sanity_check = true;
+            }, 'bar', 0);
+            expect(sanity_check).toBe(true);
           });
-        });
 
-      });
+          describe('when mappings length is greater than zero', function () {
+            it('calls walk_instances on each mapping with depth incremented',
+              function () {
+                var mr;
+                var func;
+                var fake_result = jasmine.createSpyObj(
+                  'fake_result', ['walk_instances']);
 
-      describe("when last_instance is the same as this MappingResult's instance", function() {
+                spyOn(LL.MappingResult.prototype, '_make_mappings')
+                  .and.returnValue([fake_result]);
 
-        describe("when mappings length is greater than zero", function() {
-          it("calls walk_instances on each mapping without incrementing depth", function() {
-            var fake_result = jasmine.createSpyObj("fake_result", ['walk_instances']);
-            spyOn(LL.MappingResult.prototype, "_make_mappings").and.returnValue([fake_result]);
-            var mr = new LL.MappingResult("foo", [], "bar");
-            var func = function() {};
-            mr.walk_instances(func, "foo", 0);
-            expect(fake_result.walk_instances).toHaveBeenCalledWith(func, "foo", 0);
+                mr = new LL.MappingResult('foo', [], 'bar');
+                func = function () {};
+
+                mr.walk_instances(func, 'bar', 0);
+                expect(fake_result.walk_instances)
+                  .toHaveBeenCalledWith(func, 'foo', 1);
+              }
+            );
           });
-        });
+        }
+      );
 
-        it("no action is taken", function() {
-          var sanity_check = false;
-          var mr = new LL.MappingResult("foo", [], "bar");
-          mr.walk_instances(function(instance, _result, depth) {
-            fail("fn was called");
-          }, "foo", 0);
-          expect(sanity_check).toBe(false);
-        });
-      });
+      describe('when last_instance is the same as this MappingResult\'s ' +
+        'instance',
+        function () {
+          describe('when mappings length is greater than zero', function () {
+            it('calls walk_instances on each mapping without ' +
+              'incrementing depth',
+              function () {
+                var mr;
+                var func;
+                var fake_result = jasmine.createSpyObj(
+                  'fake_result', ['walk_instances']);
 
+                spyOn(LL.MappingResult.prototype, '_make_mappings')
+                  .and.returnValue([fake_result]);
+
+                mr = new LL.MappingResult('foo', [], 'bar');
+                func = function () {};
+
+                mr.walk_instances(func, 'foo', 0);
+                expect(fake_result.walk_instances)
+                  .toHaveBeenCalledWith(func, 'foo', 0);
+              }
+            );
+          });
+
+          it('no action is taken', function () {
+            var sanity_check = false;
+            var mr = new LL.MappingResult('foo', [], 'bar');
+            mr.walk_instances(function (instance, _result, depth) {
+              fail('fn was called');
+            }, 'foo', 0);
+            expect(sanity_check).toBe(false);
+          });
+        }
+      );
     });
-
   });
 
-  describe("GGRC.ListLoaders.BaseListLoader", function() {
-
+  describe('GGRC.ListLoaders.BaseListLoader', function () {
     var ll;
-    beforeEach(function() {
+
+    beforeEach(function () {
       ll = new GGRC.ListLoaders.BaseListLoader();
-      //init_listeners is abstract -- called by base init but not implemented in base.
+      // init_listeners is abstract -- called by base init but
+      // not implemented in base.
       ll.init_listeners = jasmine.createSpy();
     });
 
-    describe("#attach", function() {
+    describe('#attach', function () {
+      it('calls the binding factory for the type', function () {
+        spyOn(GGRC.ListLoaders.BaseListLoader, 'binding_factory');
 
-      it("calls the binding factory for the type", function() {
-        spyOn(GGRC.ListLoaders.BaseListLoader, "binding_factory");
-
-        ll.attach("instance");
-        expect(GGRC.ListLoaders.BaseListLoader.binding_factory).toHaveBeenCalledWith("instance", ll);
+        ll.attach('instance');
+        expect(GGRC.ListLoaders.BaseListLoader.binding_factory)
+          .toHaveBeenCalledWith('instance', ll);
       });
 
-      it("inits the listeners", function() {
+      it('inits the listeners', function () {
         var fake_binding = {};
-        spyOn(GGRC.ListLoaders.BaseListLoader, "binding_factory").and.returnValue(fake_binding);
+        spyOn(GGRC.ListLoaders.BaseListLoader, 'binding_factory')
+          .and.returnValue(fake_binding);
 
-        ll.attach("instance");
+        ll.attach('instance');
         expect(ll.init_listeners).toHaveBeenCalledWith(fake_binding);
       });
-
     });
 
-    describe("#find_result_by_instance", function() {
+    describe('#find_result_by_instance', function () {
+      var not_found;
+      var found;
+      var list;
 
-      var not_found, found, list;
-      beforeEach(function() {
-        not_found = new GGRC.Jasmine.MockModel({ id : 1 });
-        found = new GGRC.Jasmine.MockModel({ id : 2 });
-        list = [{instance : found }];
+      beforeEach(function () {
+        not_found = new GGRC.Jasmine.MockModel({id: 1});
+        found = new GGRC.Jasmine.MockModel({id: 2});
+        list = [{instance: found}];
       });
 
-      it("returns null if no result", function() {
-        expect(ll.find_result_by_instance({ instance : not_found }, list)).toBe(null);
+      it('returns null if no result', function () {
+        expect(ll.find_result_by_instance(
+          {instance: not_found}, list)).toBe(null);
       });
 
-      it("returns the result if found", function() {
-        expect(ll.find_result_by_instance({ instance : found }, list)).toBe(list[0]);
+      it('returns the result if found', function () {
+        expect(ll.find_result_by_instance(
+          {instance: found}, list)).toBe(list[0]);
       });
-
     });
 
-    describe("#is_duplicate_result", function() {
-
-      it("returns false if instances do not match", function() {
-        expect(ll.is_duplicate_result({instance : 1}, {instance : 2 })).toBe(false);
-      });
-
-      it("returns true if instances AND mappings match", function() {
-        expect(ll.is_duplicate_result({instance : 1, mappings : 'a'}, {instance : 1, mappings : 'a' })).toBe(true);
-      });
-
-      it("returns false if either result has empty mappings", function() {
-        expect(ll.is_duplicate_result({instance : 1, mappings : null}, {instance : 1, mappings : [] })).toBe(false);
-        expect(ll.is_duplicate_result({instance : 1, mappings : []}, {instance : 1, mappings : null })).toBe(false);
-        expect(ll.is_duplicate_result({instance : 1, mappings : []}, {instance : 1, mappings : [] })).toBe(false);
-        //expect(ll.is_duplicate_result({instance : 1, mappings : 'a'}, {instance : 1, mappings : [] })).toBe(false);
-      });
-
-      it("returns false if either result has multiple mappings", function() {
-        expect(ll.is_duplicate_result({instance : 1, mappings : ['a', 'b']}, {instance : 1, mappings : ['a'] })).toBe(false);
-        expect(ll.is_duplicate_result({instance : 1, mappings : ['a']}, {instance : 1, mappings : ['a','b'] })).toBe(false);
-        expect(ll.is_duplicate_result({instance : 1, mappings : ['a','b']}, {instance : 1, mappings : ['a','b'] })).toBe(false);
-        //expect(ll.is_duplicate_result({instance : 1, mappings : 'a'}, {instance : 1, mappings : [] })).toBe(false);
-      });
-
-      it("returns true if boths results have null mappings", function() {
-        expect(ll.is_duplicate_result({instance : 1, mappings : null }, {instance : 1, mappings : null })).toBe(true);
-      });
-
-      it("returns true if both results have one non-matching mapping with no dependent mapping (instance === true)", function() {
+    describe('#is_duplicate_result', function () {
+      it('returns false if instances do not match', function () {
         expect(ll.is_duplicate_result(
-          {instance : 1, mappings : [{instance : true, mappings : [], binding : 2 }], binding : 1 },
-          {instance : 1, mappings : [{instance : true, mappings : [], binding : 2 }], binding : 1 }
+          {instance: 1}, {instance: 2}
+        )).toBe(false);
+      });
+
+      it('returns true if instances AND mappings match', function () {
+        expect(ll.is_duplicate_result(
+          {instance: 1, mappings: 'a'},
+          {instance: 1, mappings: 'a'}
         )).toBe(true);
       });
 
+      it('returns false if either result has empty mappings', function () {
+        expect(ll.is_duplicate_result(
+          {instance: 1, mappings: null},
+          {instance: 1, mappings: []}
+        )).toBe(false);
+        expect(ll.is_duplicate_result(
+          {instance: 1, mappings: []},
+          {instance: 1, mappings: null}
+        )).toBe(false);
+        expect(ll.is_duplicate_result(
+          {instance: 1, mappings: []},
+          {instance: 1, mappings: []}
+        )).toBe(false);
+      });
+
+      it('returns false if either result has multiple mappings', function () {
+        expect(ll.is_duplicate_result(
+          {instance: 1, mappings: ['a', 'b']},
+          {instance: 1, mappings: ['a']}
+        )).toBe(false);
+        expect(ll.is_duplicate_result(
+          {instance: 1, mappings: ['a']},
+          {instance: 1, mappings: ['a', 'b']}
+        )).toBe(false);
+        expect(
+          ll.is_duplicate_result(
+            {instance: 1, mappings: ['a', 'b']},
+            {instance: 1, mappings: ['a', 'b']}
+          )).toBe(false);
+      });
+
+      it('returns true if boths results have null mappings', function () {
+        expect(ll.is_duplicate_result(
+          {instance: 1, mappings: null},
+          {instance: 1, mappings: null}
+        )).toBe(true);
+      });
+
+      it('returns true if both results have one non-matching mapping with ' +
+        'no dependent mapping (instance === true)',
+        function () {
+          expect(ll.is_duplicate_result(
+            {
+              instance: 1,
+              mappings: [{instance: true, mappings: [], binding: 2}],
+              binding: 1
+            },
+            {
+              instance: 1,
+              mappings: [{instance: true, mappings: [], binding: 2}],
+              binding: 1
+            }
+          )).toBe(true);
+        }
+      );
     });
 
-    describe("#insert_results", function() {
+    describe('#insert_results', function () {
+      var binding;
+      var fake_find_result;
 
-      var binding, fake_find_result;
-      beforeEach(function() {
-        fake_find_result = { mappings : [] };
-        spyOn(ll, "find_result_by_instance");
-        spyOn(ll, "is_duplicate_result");
-        spyOn(ll, "make_result").and.returnValue(fake_find_result);
-        binding = { list : [] };
+      beforeEach(function () {
+        fake_find_result = {mappings: []};
+        spyOn(ll, 'find_result_by_instance');
+        spyOn(ll, 'is_duplicate_result');
+        spyOn(ll, 'make_result').and.returnValue(fake_find_result);
+        binding = {list: []};
       });
 
-      it("returns an empty list, and pushes nothing to binding, if no results", function() {
-        var ret = ll.insert_results(binding, []);
-        expect(ret).toEqual([]);
-        expect(binding.list).toEqual([]);
-      });
+      it('returns an empty list, and pushes nothing to binding, if no results',
+        function () {
+          var ret = ll.insert_results(binding, []);
+          expect(ret).toEqual([]);
+          expect(binding.list).toEqual([]);
+        }
+      );
 
-
-      it("returns a list with inserted bindings, if results", function() {
+      it('returns a list with inserted bindings, if results', function () {
         var ret = ll.insert_results(binding, ['a']);
         expect(ret).toEqual([fake_find_result]);
         expect(binding.list).toEqual([fake_find_result]);
       });
 
-      it("returns an empty list, and pushes nothing to binding, if results are duplicates", function() {
-        var ret;
-        ll.find_result_by_instance.and.returnValue(fake_find_result);
-        ll.is_duplicate_result.and.returnValue(true);
-        ret = ll.insert_results(binding, ['a']);
-        expect(ret).toEqual([]);
-        expect(binding.list).toEqual([]);
-      });
-
+      it('returns an empty list, and pushes nothing to binding, if results ' +
+        'are duplicates',
+        function () {
+          var ret;
+          ll.find_result_by_instance.and.returnValue(fake_find_result);
+          ll.is_duplicate_result.and.returnValue(true);
+          ret = ll.insert_results(binding, ['a']);
+          expect(ret).toEqual([]);
+          expect(binding.list).toEqual([]);
+        }
+      );
     });
 
-    describe("#remove_instances", function() {
-
+    describe('#remove_instances', function () {
       var Dummy;
-      beforeAll(function() {
+      beforeAll(function () {
         Dummy = can.Map.extend();
-        Dummy.shortName = "Dummy";
+        Dummy.shortName = 'Dummy';
       });
 
-      it("removes no instance when nothing is supplied to remove", function() {
-        var instance =  new Dummy({ id : 3 });
-        var binding = { list : [{ instance : instance, mappings : [] }] };
+      it('removes no instance when nothing is supplied to remove', function () {
+        var instance = new Dummy({id: 3});
+        var binding = {list: [{instance: instance, mappings: []}]};
         ll.remove_instance(binding, {}, 'b');
-        expect(binding.list).toEqual([{ instance : instance, mappings : [] }]);
+        expect(binding.list).toEqual([{instance: instance, mappings: []}]);
       });
 
-      it("removes no instance when instance doesn't match type", function() {
-        var instance =  new Dummy({ id : 3 });
+      it('removes no instance when instance doesn\'t match type', function () {
+        var instance = new Dummy({id: 3});
         var WrongClass = can.Map.extend();
-        WrongClass.shortName = "Wrong";
-        var wrong_instance = new WrongClass({ id : 3 });
-        var binding = { list : [{ instance : instance, mappings : [] }] };
+        var wrong_instance;
+        var binding;
+
+        WrongClass.shortName = 'Wrong';
+        wrong_instance = new WrongClass({id: 3});
+        binding = {list: [{instance: instance, mappings: []}]};
+
         ll.remove_instance(binding, wrong_instance, 'b');
-        expect(binding.list).toEqual([{ instance : instance, mappings : [] }]);
+
+        expect(binding.list).toEqual([{instance: instance, mappings: []}]);
       });
 
-      it("removes the instance from mappings when matching", function() {
-        var instance =  new Dummy({ id : 3 });
-        var binding = { list : [{ instance : instance, mappings : [] }] };
+      it('removes the instance from mappings when matching', function () {
+        var instance = new Dummy({id: 3});
+        var binding = {list: [{instance: instance, mappings: []}]};
         ll.remove_instance(binding, instance, 'b');
         expect(binding.list).toEqual([]);
       });
 
-      it("removes the instance from mappings on just type and ID match", function() {
-        var instance =  new Dummy({ id : 3 });
-        var matching_instance = new Dummy({ id : 3 });
-        var binding = { list : [{ instance : instance, mappings : [] }] };
-        expect(matching_instance).not.toBe(instance);
-        ll.remove_instance(binding, matching_instance, 'b');
-        expect(binding.list).toEqual([]);
-      });
-      
-      describe("with mappings defined", function() {
-
-        it("deletes only if all mappings are accounted for in instance", function() {
-          var instance =  new Dummy({ id : 3 });
-          var binding = {
-            list : [{
-              instance : instance,
-              mappings : ['a', 'b'],
-              remove_mapping: function(mapping) {
-                var idx = can.inArray(mapping, this.mappings);
-                if(~idx) {
-                  this.mappings.splice(idx, 1);
-                  return true;
-                }
-              }
-            }]
-          };
-          ll.remove_instance(binding, instance, ['a', 'b']);
+      it('removes the instance from mappings on just type and ID match',
+        function () {
+          var instance = new Dummy({id: 3});
+          var matching_instance = new Dummy({id: 3});
+          var binding = {list: [{instance: instance, mappings: []}]};
+          expect(matching_instance).not.toBe(instance);
+          ll.remove_instance(binding, matching_instance, 'b');
           expect(binding.list).toEqual([]);
-        });
+        }
+      );
 
-        it("does not delete if not all mappings are accounted for", function() {
-          var instance =  new Dummy({ id : 3 });
-          var binding = {
-            list : [{
-              instance : instance,
-              mappings : ['a', 'b'],
-              remove_mapping: function(mapping) {
-                var idx = can.inArray(mapping, this.mappings);
-                if(~idx) {
-                  this.mappings.splice(idx, 1);
-                  return true;
+      describe('with mappings defined', function () {
+        it('deletes only if all mappings are accounted for in instance',
+          function () {
+            var instance = new Dummy({id: 3});
+            var binding = {
+              list: [{
+                instance: instance,
+                mappings: ['a', 'b'],
+                remove_mapping: function (mapping) {
+                  var idx = can.inArray(mapping, this.mappings);
+                  if (~idx) {
+                    this.mappings.splice(idx, 1);
+                    return true;
+                  }
                 }
-              }
-            }]
-          };
-          ll.remove_instance(binding, instance, ['a']); //only one of the mappings
-          expect(binding.list).toEqual([{ instance : instance, mappings : ['b'], remove_mapping: jasmine.any(Function) }]);
-        });
-      });
+              }]
+            };
+            ll.remove_instance(binding, instance, ['a', 'b']);
+            expect(binding.list).toEqual([]);
+          }
+        );
 
-    });
+        it('does not delete if not all mappings are accounted for',
+          function () {
+            var instance = new Dummy({id: 3});
+            var binding = {
+              list: [{
+                instance: instance,
+                mappings: ['a', 'b'],
+                remove_mapping: function (mapping) {
+                  var idx = can.inArray(mapping, this.mappings);
+                  if (~idx) {
+                    this.mappings.splice(idx, 1);
+                    return true;
+                  }
+                }
+              }]
+            };
 
-    describe("#refresh_stubs", function() {
+             // only one of the mappings
+            ll.remove_instance(binding, instance, ['a']);
 
-      it("returns promise based on existing deferred, returning binding list, if it exists", function() {
-        var binding = { list : [] },
-            source_dfd = binding._refresh_stubs_deferred = new $.Deferred(),
-            ret = ll.refresh_stubs(binding),
-            sanity = false;
-        source_dfd.resolve();
-        ret.done(function(data) {
-          expect(data).toBe(binding.list);
-          sanity = true;
-        });
-        if(!sanity) {
-          fail("sanity check failed for done callback from returned promise");
-        }
-      });
-
-      it("makes new refresh stubs deferred, returning binding list, if it does not already exist", function() {
-        var ret,
-            binding = { list : [] },
-            sanity = false;
-        ll._refresh_stubs = jasmine.createSpy().and.returnValue($.when());
-        ret = ll.refresh_stubs(binding);
-        ret.done(function(data) {
-          expect(data).toBe(binding.list);
-          sanity = true;
-        });
-        if(!sanity) {
-          fail("sanity check failed for done callback from returned promise");
-        }
-        expect(ll._refresh_stubs).toHaveBeenCalled();
+            expect(binding.list).toEqual([{
+              instance: instance,
+              mappings: ['b'],
+              remove_mapping: jasmine.any(Function)
+            }]);
+          }
+        );
       });
     });
 
-    describe("#refresh_instances", function() {
+    describe('#refresh_stubs', function () {
+      it('returns promise based on existing deferred, returning binding ' +
+        'list, if it exists',
+        function () {
+          var binding = {list: []};
+          var source_dfd = binding._refresh_stubs_deferred = new $.Deferred();
+          var ret = ll.refresh_stubs(binding);
+          var sanity = false;
 
-      it("returns promise based on existing deferred, returning binding list, if it exists", function() {
-        var binding = { list : [] },
-            source_dfd = binding._refresh_instances_deferred = new $.Deferred(),
-            ret = ll.refresh_instances(binding),
-            sanity = false;
-        source_dfd.resolve();
-        ret.done(function(data) {
-          expect(data).toBe(binding.list);
-          sanity = true;
-        });
-        if(!sanity) {
-          fail("sanity check failed for done callback from returned promise");
+          source_dfd.resolve();
+          ret.done(function (data) {
+            expect(data).toBe(binding.list);
+            sanity = true;
+          });
+          if (!sanity) {
+            fail('sanity check failed for done callback from returned promise');
+          }
         }
-      });
+      );
 
-      it("makes new refresh instances deferred, returning binding list, if it does not already exist", function() {
-        var ret,
-            binding = { list : [] },
-            sanity = false;
-        ll._refresh_instances = jasmine.createSpy().and.returnValue($.when());
-        ret = ll.refresh_instances(binding);
-        ret.done(function(data) {
-          expect(data).toBe(binding.list);
-          sanity = true;
-        });
-        if(!sanity) {
-          fail("sanity check failed for done callback from returned promise");
+      it('makes new refresh stubs deferred, returning binding list, if it ' +
+        'does not already exist',
+        function () {
+          var ret;
+          var binding = {list: []};
+          var sanity = false;
+
+          ll._refresh_stubs = jasmine.createSpy().and.returnValue($.when());
+          ret = ll.refresh_stubs(binding);
+          ret.done(function (data) {
+            expect(data).toBe(binding.list);
+            sanity = true;
+          });
+          if (!sanity) {
+            fail('sanity check failed for done callback from returned promise');
+          }
+          expect(ll._refresh_stubs).toHaveBeenCalled();
         }
-        expect(ll._refresh_instances).toHaveBeenCalled();
-      });
+      );
     });
 
-    describe("#_refresh_instances", function() {
+    describe('#refresh_instances', function () {
+      it('returns promise based on existing deferred, returning binding ' +
+        'list, if it exists',
+        function () {
+          var binding = {list: []};
+          var source_dfd =
+            (binding._refresh_instances_deferred = new $.Deferred());
+          var ret = ll.refresh_instances(binding);
+          var sanity = false;
 
-      it("returns promise based on binding list", function() {
-        var ret,
-            binding = { list : [{instance : 'a'}] },
-            sanity = false;
-        spyOn(ll, "refresh_stubs").and.returnValue($.when());
-        spyOn(RefreshQueue.prototype, "trigger").and.callFake(function() {
+          source_dfd.resolve();
+          ret.done(function (data) {
+            expect(data).toBe(binding.list);
+            sanity = true;
+          });
+          if (!sanity) {
+            fail('sanity check failed for done callback from returned promise');
+          }
+        }
+      );
+
+      it('makes new refresh instances deferred, returning binding list, if' +
+        'it does not already exist',
+        function () {
+          var ret;
+          var binding = {list: []};
+          var sanity = false;
+
+          ll._refresh_instances = jasmine.createSpy().and.returnValue($.when());
+          ret = ll.refresh_instances(binding);
+          ret.done(function (data) {
+            expect(data).toBe(binding.list);
+            sanity = true;
+          });
+          if (!sanity) {
+            fail('sanity check failed for done callback from returned promise');
+          }
+          expect(ll._refresh_instances).toHaveBeenCalled();
+        }
+      );
+    });
+
+    describe('#_refresh_instances', function () {
+      it('returns promise based on binding list', function () {
+        var ret;
+        var binding = {
+          list: [{instance: 'a'}]
+        };
+        var sanity = false;
+
+        spyOn(ll, 'refresh_stubs').and.returnValue($.when());
+        spyOn(RefreshQueue.prototype, 'trigger').and.callFake(function () {
           return $.when(this.objects);
         });
 
         ret = ll._refresh_instances(binding);
-        ret.done(function(data) {
+        ret.done(function (data) {
           expect(data).toEqual(['a']);
           sanity = true;
         });
-        if(!sanity) {
-          fail("sanity check failed for done callback from returned promise");
+        if (!sanity) {
+          fail('sanity check failed for done callback from returned promise');
         }
       });
-
     });
-
   });
 
-  describe("GGRC.ListLoaders.ReifyingListLoader", function() {
-
-    describe("#init", function() {
-      beforeEach(function() {
-        spyOn(LL.BaseListLoader.prototype, "init");
+  describe('GGRC.ListLoaders.ReifyingListLoader', function () {
+    describe('#init', function () {
+      beforeEach(function () {
+        spyOn(LL.BaseListLoader.prototype, 'init');
       });
 
-      it("sets source_binding property if binding is a ListBinding", function() {
-        var binding = new LL.ListBinding(),
-            rll = new LL.ReifyingListLoader(binding);
-        expect(rll.source_binding).toBe(binding);
-        expect(rll.binding).not.toBeDefined();
-      });
+      it('sets source_binding property if binding is a ListBinding',
+        function () {
+          var binding = new LL.ListBinding();
+          var rll = new LL.ReifyingListLoader(binding);
+          expect(rll.source_binding).toBe(binding);
+          expect(rll.binding).not.toBeDefined();
+        }
+      );
 
-      it("sets source property if binding is not a ListBinding", function() {
-        var binding = {},
-            rll = new LL.ReifyingListLoader(binding);
+      it('sets source property if binding is not a ListBinding', function () {
+        var binding = {};
+        var rll = new LL.ReifyingListLoader(binding);
         expect(rll.source).toBe(binding);
         expect(rll.source_binding).not.toBeDefined();
       });
-
     });
 
-    describe("#insert_from_source_binding", function() {
-      beforeEach(function() {
-        spyOn(RefreshQueue.prototype, "trigger").and.callFake(function() {
+    describe('#insert_from_source_binding', function () {
+      beforeEach(function () {
+        spyOn(RefreshQueue.prototype, 'trigger').and.callFake(function () {
           return $.when(this.objects);
         });
       });
 
-      it("makes a new binding referencing the instance and old mappings", function() {
-        var rll = new LL.ReifyingListLoader(),
-            binding = {},
-            results = [rll.make_result('a', [])],
-            expected = [rll.make_result(results[0].instance, results, {})];
-        spyOn(rll, "insert_results");
-        rll.insert_from_source_binding(binding, results);
-        expect(rll.insert_results).toHaveBeenCalledWith(binding, expected);
-      });
+      it('makes a new binding referencing the instance and old mappings',
+        function () {
+          var rll = new LL.ReifyingListLoader();
+          var binding = {};
+          var results = [rll.make_result('a', [])];
+          var expected = [rll.make_result(results[0].instance, results, {})];
+
+          spyOn(rll, 'insert_results');
+          rll.insert_from_source_binding(binding, results);
+          expect(rll.insert_results).toHaveBeenCalledWith(binding, expected);
+        }
+      );
     });
 
-    describe("#init_listeners", function() {
+    describe('#init_listeners', function () {
+      var rll;
+      var binding;
+      var source_binding;
 
-      var rll, binding, source_binding;
-      beforeEach(function() {
+      beforeEach(function () {
         source_binding = new LL.ListBinding();
         binding = new LL.ListBinding();
       });
-      it("sets up source_binding on the binding from the ReifyingListLoader's source_binding, if it exists", function() {
-        rll = new LL.ReifyingListLoader(source_binding);
-        spyOn(rll, "insert_from_source_binding");
-        rll.init_listeners(binding);
-        expect(binding.source_binding).toBe(source_binding);
-        expect(rll.insert_from_source_binding).toHaveBeenCalledWith(binding, source_binding.list, 0);
-      });
 
-      it("sets up source_binding from the binding via get_binding, if the source_binding property does not exist", function() {
-        rll = new LL.ReifyingListLoader("dummy_binding");
-        spyOn(rll, "insert_from_source_binding");
-        binding = { instance : { "get_binding" : function() { return source_binding; }}};
-        rll.init_listeners(binding);
-        expect(binding.source_binding).toBe(source_binding);
-        expect(rll.insert_from_source_binding).toHaveBeenCalledWith(binding, source_binding.list, 0);
-      });
+      it('sets up source_binding on the binding from the ' +
+        'ReifyingListLoader\'s source_binding, if it exists',
+        function () {
+          rll = new LL.ReifyingListLoader(source_binding);
+          spyOn(rll, 'insert_from_source_binding');
+          rll.init_listeners(binding);
+          expect(binding.source_binding).toBe(source_binding);
+          expect(rll.insert_from_source_binding)
+            .toHaveBeenCalledWith(binding, source_binding.list, 0);
+        }
+      );
 
+      it('sets up source_binding from the binding via get_binding, if the ' +
+        'source_binding property does not exist',
+        function () {
+          rll = new LL.ReifyingListLoader('dummy_binding');
+          spyOn(rll, 'insert_from_source_binding');
+          binding = {
+            instance: {
+              get_binding: function () {
+                return source_binding;
+              }
+            }
+          };
+          rll.init_listeners(binding);
+          expect(binding.source_binding).toBe(source_binding);
+          expect(rll.insert_from_source_binding)
+            .toHaveBeenCalledWith(binding, source_binding.list, 0);
+        }
+      );
     });
 
-    describe("listeners", function() {
-      var rll, binding, source_binding;
-      beforeEach(function() {
+    describe('listeners', function () {
+      var rll;
+      var binding;
+      var source_binding;
+
+      beforeEach(function () {
         source_binding = new LL.ListBinding();
         binding = new LL.ListBinding();
         rll = new LL.ReifyingListLoader(source_binding);
       });
 
-      describe("source_binding.list add", function() {
-        it("calls insert_from_source_binding on the list loader", function() {
-          var new_result = new LL.MappingResult({id : 1}, []);
-          spyOn(rll, "insert_from_source_binding");
+      describe('source_binding.list add', function () {
+        it('calls insert_from_source_binding on the list loader', function () {
+          var new_result = new LL.MappingResult({id: 1}, []);
+          spyOn(rll, 'insert_from_source_binding');
           rll.init_listeners(binding);
           source_binding.list.push(new_result);
-          expect(rll.insert_from_source_binding).toHaveBeenCalledWith(binding, [new_result], 0);
+          expect(rll.insert_from_source_binding)
+            .toHaveBeenCalledWith(binding, [new_result], 0);
         });
       });
 
-      describe("source_binding.list remove", function() {
-        it("calls remove_instance on the list loader for each item", function() {
-          var new_result = new LL.MappingResult({id : 1}, []);
-          spyOn(RefreshQueue.prototype, "trigger").and.returnValue($.when()); //Avoid AJAX
-          spyOn(rll, "remove_instance");
-          binding.list.push(new_result);
-          source_binding.list.push(new_result);
-          rll.init_listeners(binding);
-          source_binding.list.shift();
-          expect(rll.remove_instance).toHaveBeenCalledWith(binding, new_result.instance, new_result);
-        });
+      describe('source_binding.list remove', function () {
+        it('calls remove_instance on the list loader for each item',
+          function () {
+            var new_result = new LL.MappingResult({id: 1}, []);
+            spyOn(RefreshQueue.prototype, 'trigger')
+              .and.returnValue($.when());  // Avoid AJAX
+            spyOn(rll, 'remove_instance');
+            binding.list.push(new_result);
+            source_binding.list.push(new_result);
+            rll.init_listeners(binding);
+            source_binding.list.shift();
+            expect(rll.remove_instance)
+              .toHaveBeenCalledWith(binding, new_result.instance, new_result);
+          }
+        );
       });
     });
   });
 
-  describe("GGRC.ListLoaders.CustomFilteredListLoader", function() {
+  describe('GGRC.ListLoaders.CustomFilteredListLoader', function () {
+    var cfll;
+    var binding;
 
-    var cfll, binding;
-    beforeEach(function() {
+    beforeEach(function () {
       binding = new LL.ListBinding();
       binding.source_binding = new LL.ListBinding();
       cfll = new LL.CustomFilteredListLoader(binding, jasmine.createSpy());
     });
 
-    describe("_refresh_stubs", function() {
-
-      it("gets results from binding's source binding", function() {
-        var mock_inst = new GGRC.Jasmine.MockModel({ value : 'a' });
-        spyOn(binding.source_binding, "refresh_instances").and.returnValue(new $.Deferred().reject());
+    describe('_refresh_stubs', function () {
+      it('gets results from binding\'s source binding', function () {
+        spyOn(binding.source_binding, 'refresh_instances')
+          .and.returnValue(new $.Deferred().reject());
 
         cfll._refresh_stubs(binding);
         expect(binding.source_binding.refresh_instances).toHaveBeenCalled();
       });
 
-      it("runs all results from source binding through filter function", function() {
-        var mock_inst = new GGRC.Jasmine.MockModel({ value : 'a' });
-        var mock_result = { instance : mock_inst, mappings: [] };
-        spyOn(binding.source_binding, "refresh_instances").and.returnValue(new $.Deferred().resolve([mock_result]));
+      it('runs all results from source binding through filter function',
+        function () {
+          var mock_inst = new GGRC.Jasmine.MockModel({value: 'a'});
+          var mock_result = {instance: mock_inst, mappings: []};
+          spyOn(binding.source_binding, 'refresh_instances')
+            .and.returnValue(new $.Deferred().resolve([mock_result]));
 
-        // Items are sent through a refresh queue before continuing.
-        spyOn(RefreshQueue.prototype, "trigger").and.returnValue($.when([mock_inst]));
+          // Items are sent through a refresh queue before continuing.
+          spyOn(RefreshQueue.prototype, 'trigger')
+            .and.returnValue($.when([mock_inst]));
 
-        cfll._refresh_stubs(binding);
-        expect(cfll.filter_fn).toHaveBeenCalledWith(mock_result);
-      });
-
+          cfll._refresh_stubs(binding);
+          expect(cfll.filter_fn).toHaveBeenCalledWith(mock_result);
+        }
+      );
     });
 
-    describe("listeners", function() {
-      var cfll, binding, source_binding, new_result;
-      beforeEach(function() {
-        new_result = new LL.MappingResult({id : 1}, []);
+    describe('listeners', function () {
+      var cfll;
+      var binding;
+      var source_binding;
+      var new_result;
+
+      beforeEach(function () {
+        new_result = new LL.MappingResult({id: 1}, []);
         source_binding = new LL.ListBinding();
         binding = new LL.ListBinding();
-        cfll = new LL.CustomFilteredListLoader(source_binding, jasmine.createSpy("filter_fn"));
-        spyOn(binding, "refresh_instances").and.returnValue($.when());
+        cfll = new LL.CustomFilteredListLoader(
+          source_binding, jasmine.createSpy('filter_fn'));
+        spyOn(binding, 'refresh_instances').and.returnValue($.when());
         // Items are sent through a refresh queue before continuing.
-        spyOn(RefreshQueue.prototype, "trigger").and.returnValue($.when([new_result.instance]));
+        spyOn(RefreshQueue.prototype, 'trigger')
+          .and.returnValue($.when([new_result.instance]));
       });
 
-      describe("source_binding.list add", function() {
-        it("calls custom filter func on the list loader", function() {
+      describe('source_binding.list add', function () {
+        it('calls custom filter func on the list loader', function () {
           cfll.init_listeners(binding);
           source_binding.list.push(new_result);
           expect(cfll.filter_fn).toHaveBeenCalledWith(new_result);
         });
 
-        it("adds the new item when the filter func returns true", function() {
-          var filter_result = new LL.MappingResult({id : 2}, [new_result]);
+        it('adds the new item when the filter func returns true', function () {
+          var filter_result = new LL.MappingResult({id: 2}, [new_result]);
           cfll.filter_fn.and.returnValue(true);
           cfll.init_listeners(binding);
-          spyOn(cfll, "make_result").and.returnValue(filter_result);
-          spyOn(cfll, "insert_results");
+          spyOn(cfll, 'make_result').and.returnValue(filter_result);
+          spyOn(cfll, 'insert_results');
           source_binding.list.push(new_result);
-          expect(cfll.insert_results).toHaveBeenCalledWith(binding, [filter_result]);
+          expect(cfll.insert_results)
+            .toHaveBeenCalledWith(binding, [filter_result]);
         });
 
-        it("does not add the new item when the filter func returns false", function() {
-          var filter_result = new LL.MappingResult({id : 2}, [new_result]);
-          cfll.filter_fn.and.returnValue(false);
-          cfll.init_listeners(binding);
-          spyOn(cfll, "make_result").and.returnValue(filter_result);
-          spyOn(cfll, "insert_results");
-          spyOn(cfll, "remove_instance");
-          source_binding.list.push(new_result);
-          expect(cfll.insert_results).not.toHaveBeenCalledWith(binding, [filter_result]);
-          expect(cfll.remove_instance).toHaveBeenCalledWith(binding, new_result.instance, new_result);
-        });
+        it('does not add the new item when the filter func returns false',
+          function () {
+            var filter_result = new LL.MappingResult({id: 2}, [new_result]);
+            cfll.filter_fn.and.returnValue(false);
+            cfll.init_listeners(binding);
+            spyOn(cfll, 'make_result').and.returnValue(filter_result);
+            spyOn(cfll, 'insert_results');
+            spyOn(cfll, 'remove_instance');
+            source_binding.list.push(new_result);
+            expect(cfll.insert_results)
+              .not.toHaveBeenCalledWith(binding, [filter_result]);
+            expect(cfll.remove_instance)
+              .toHaveBeenCalledWith(binding, new_result.instance, new_result);
+          }
+        );
 
-        it("adds the new item when the filter func returns a deferred resolving to true", function() {
-          var filter_result = new LL.MappingResult({id : 2}, [new_result]);
-          cfll.filter_fn.and.returnValue($.when(true));
-          cfll.init_listeners(binding);
-          spyOn(cfll, "make_result").and.returnValue(filter_result);
-          spyOn(cfll, "insert_results");
-          source_binding.list.push(new_result);
-          expect(cfll.insert_results).toHaveBeenCalledWith(binding, [filter_result]);
-        });
+        it('adds the new item when the filter func returns a deferred ' +
+          'resolving to true',
+          function () {
+            var filter_result = new LL.MappingResult({id: 2}, [new_result]);
+            cfll.filter_fn.and.returnValue($.when(true));
+            cfll.init_listeners(binding);
+            spyOn(cfll, 'make_result').and.returnValue(filter_result);
+            spyOn(cfll, 'insert_results');
+            source_binding.list.push(new_result);
+            expect(cfll.insert_results)
+              .toHaveBeenCalledWith(binding, [filter_result]);
+          }
+        );
 
-        it("does not add the new item when the filter func returns a deferred resolving to false", function() {
-          var filter_result = new LL.MappingResult({id : 2}, [new_result]);
-          cfll.filter_fn.and.returnValue($.when(false));
-          cfll.init_listeners(binding);
-          spyOn(cfll, "make_result").and.returnValue(filter_result);
-          spyOn(cfll, "insert_results");
-          spyOn(cfll, "remove_instance");
-          source_binding.list.push(new_result);
-          expect(cfll.insert_results).not.toHaveBeenCalledWith(binding, [filter_result]);
-          expect(cfll.remove_instance).toHaveBeenCalledWith(binding, new_result.instance, new_result);
-        });
+        it('does not add the new item when the filter func returns a' +
+          'deferred resolving to false',
+          function () {
+            var filter_result = new LL.MappingResult({id: 2}, [new_result]);
+            cfll.filter_fn.and.returnValue($.when(false));
+            cfll.init_listeners(binding);
+            spyOn(cfll, 'make_result').and.returnValue(filter_result);
+            spyOn(cfll, 'insert_results');
+            spyOn(cfll, 'remove_instance');
+            source_binding.list.push(new_result);
+            expect(cfll.insert_results)
+              .not.toHaveBeenCalledWith(binding, [filter_result]);
+            expect(cfll.remove_instance)
+              .toHaveBeenCalledWith(binding, new_result.instance, new_result);
+          }
+        );
 
-        it("does not add the new item when the filter func returns a deferred that rejects", function() {
-          var filter_result = new LL.MappingResult({id : 2}, [new_result]);
-          cfll.filter_fn.and.returnValue(new $.Deferred().reject());
-          cfll.init_listeners(binding);
-          spyOn(cfll, "make_result").and.returnValue(filter_result);
-          spyOn(cfll, "insert_results");
-          spyOn(cfll, "remove_instance");
-          source_binding.list.push(new_result);
-          expect(cfll.insert_results).not.toHaveBeenCalledWith(binding, [filter_result]);
-          expect(cfll.remove_instance).toHaveBeenCalledWith(binding, new_result.instance, new_result);
-        });
-
+        it('does not add the new item when the filter func returns' +
+          'a deferred that rejects',
+          function () {
+            var filter_result = new LL.MappingResult({id: 2}, [new_result]);
+            cfll.filter_fn.and.returnValue(new $.Deferred().reject());
+            cfll.init_listeners(binding);
+            spyOn(cfll, 'make_result').and.returnValue(filter_result);
+            spyOn(cfll, 'insert_results');
+            spyOn(cfll, 'remove_instance');
+            source_binding.list.push(new_result);
+            expect(cfll.insert_results)
+              .not.toHaveBeenCalledWith(binding, [filter_result]);
+            expect(cfll.remove_instance)
+              .toHaveBeenCalledWith(binding, new_result.instance, new_result);
+          }
+        );
       });
 
-      describe("source_binding.list remove", function() {
-        it("calls remove_instance on the list loader for each item", function() {
-          var new_result = new LL.MappingResult({id : 1}, []);
-          spyOn(cfll, "remove_instance");
-          binding.list.push(new_result);
-          source_binding.list.push(new_result);
-          cfll.init_listeners(binding);
-          source_binding.list.shift();
-          expect(cfll.remove_instance).toHaveBeenCalledWith(binding, new_result.instance, new_result);
-        });
+      describe('source_binding.list remove', function () {
+        it('calls remove_instance on the list loader for each item',
+          function () {
+            var newResult = new LL.MappingResult({id: 1}, []);
+            spyOn(cfll, 'remove_instance');
+            binding.list.push(newResult);
+            source_binding.list.push(newResult);
+            cfll.init_listeners(binding);
+            source_binding.list.shift();
+            expect(cfll.remove_instance)
+              .toHaveBeenCalledWith(binding, newResult.instance, newResult);
+          }
+        );
       });
     });
-
   });
-
 });

--- a/src/ggrc/assets/js_specs/models/recently_viewed_object_spec.js
+++ b/src/ggrc/assets/js_specs/models/recently_viewed_object_spec.js
@@ -5,40 +5,48 @@
     Maintained By: brad@reciprocitylabs.com
 */
 
-describe("can.Model.RecentlyViewedObjects", function() {
+describe('can.Model.RecentlyViewedObjects', function () {
+  describe('::newInstance', function () {
+    it('creates a new recently viewed object given non-Model instance',
+      function () {
+        var obj = GGRC.Models.RecentlyViewedObject.newInstance({foo: 'bar'});
+        expect(obj.foo).toBe('bar');
+        expect(obj instanceof GGRC.Models.RecentlyViewedObject).toBeTruthy();
+      }
+    );
 
-  describe("::newInstance", function() {
-    it("creates a new recently viewed object given non-Model instance", function() {
-      var obj = GGRC.Models.RecentlyViewedObject.newInstance({"foo": "bar"});
-      expect(obj.foo).toBe("bar");
-      expect(obj instanceof GGRC.Models.RecentlyViewedObject).toBeTruthy();
-    });
+    it('references original Model type when passed in as argument',
+      function () {
+        var obj;
+        var rvoObj;
 
-    it("references original Model type when passed in as argument", function() {
-      spyOn(GGRC.Models.RecentlyViewedObject.prototype, "init");
-      can.Model("RVO");
-      var obj = new RVO({
-          viewLink: "/"
-          , title: "blah"
-      });
-      var rvo_obj = GGRC.Models.RecentlyViewedObject.newInstance(obj);
-      expect(rvo_obj.type).toBe("RVO");
-      expect(rvo_obj.model).toBe(RVO);
-      expect(rvo_obj.viewLink).toBe("/");
-      expect(rvo_obj.title).toBe("blah");
-    });
+        spyOn(GGRC.Models.RecentlyViewedObject.prototype, 'init');
+        can.Model('RVO');
+        obj = new window.RVO({
+          viewLink: '/',
+          title: 'blah'
+        });
+
+        rvoObj = GGRC.Models.RecentlyViewedObject.newInstance(obj);
+        expect(rvoObj.type).toBe('RVO');
+        expect(rvoObj.model).toBe(window.RVO);
+        expect(rvoObj.viewLink).toBe('/');
+        expect(rvoObj.title).toBe('blah');
+      }
+    );
   });
 
-  describe("#stub", function() {
-    it("include title and view link", function() {
+  describe('#stub', function () {
+    it('include title and view link', function () {
       var obj = {
-          viewLink: "/"
-          , title: "blah"
+        viewLink: '/',
+        title: 'blah'
       };
-      var rvo_obj = new GGRC.Models.RecentlyViewedObject(obj).stub();
-      expect(rvo_obj.title).toBe("blah");
-      expect(rvo_obj.viewLink).toBe("/");
-      expect(rvo_obj.id).not.toBeDefined();
+      var rvoObj = new GGRC.Models.RecentlyViewedObject(obj).stub();
+
+      expect(rvoObj.title).toBe('blah');
+      expect(rvoObj.viewLink).toBe('/');
+      expect(rvoObj.id).not.toBeDefined();
     });
   });
 });

--- a/src/ggrc/assets/js_specs/mustache_helpers/debugger_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/debugger_spec.js
@@ -5,26 +5,25 @@
   Maintained By: peter@reciprocitylabs.com
 */
 
-describe("can.mustache.helper.debugger", function () {
-  var fakeOptions,
-      helper;
+describe('can.mustache.helper.debugger', function () {
+  var fakeOptions;
+  var helper;
 
   beforeAll(function () {
     fakeOptions = {
       fn: jasmine.createSpy()
     };
 
-    helper = can.Mustache._helpers["debugger"].fn;
+    helper = can.Mustache._helpers.debugger.fn;
   });
 
-  it("does not throw an error when called with more than one argument",
+  it('does not throw an error when called with more than one argument',
     function () {
       try {
-        helper(1, "foo", ["bar"], fakeOptions);
+        helper(1, 'foo', ['bar'], fakeOptions);
       } catch (ex) {
-        fail("Helper threw an error: " + ex.message);
+        fail('Helper threw an error: ' + ex.message);
       }
     }
   );
-
 });

--- a/src/ggrc/assets/js_specs/mustache_helpers/file_type_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/file_type_spec.js
@@ -5,11 +5,11 @@
   Maintained By: peter@reciprocitylabs.com
 */
 
-describe("can.mustache.helper.file_type", function () {
-  "use strict";
+describe('can.mustache.helper.file_type', function () {
+  'use strict';
 
-  var helper,
-      instance;  // the argument passed to the helper on invocation
+  var helper;
+  var instance;  // the argument passed to the helper on invocation
 
   beforeAll(function () {
     helper = can.Mustache._helpers.file_type.fn;
@@ -17,26 +17,26 @@ describe("can.mustache.helper.file_type", function () {
 
   beforeEach(function () {
     instance = {
-      type: "Document",
-      title: "foo.bar"
+      type: 'Document',
+      title: 'foo.bar'
     };
   });
 
-  it("raises an error if passed an object of type other than Document",
+  it('raises an error if passed an object of type other than Document',
     function () {
-      var callWithInvalid,
-          errMsg = "Cannot determine file type for a non-document object";
+      var callWithInvalid;
+      var errMsg = 'Cannot determine file type for a non-document object';
 
-      instance.type = "FooBar";
+      instance.type = 'FooBar';
       callWithInvalid = helper.bind(helper, instance);
 
       expect(callWithInvalid).toThrow(errMsg);
     }
   );
 
-  it("raises an error if the file name cannot be determined", function () {
-    var callWithInvalid,
-        errMsg = "Cannot determine the object's file name";
+  it('raises an error if the file name cannot be determined', function () {
+    var callWithInvalid;
+    var errMsg = 'Cannot determine the object\'s file name';
 
     instance.title = undefined;
     callWithInvalid = helper.bind(helper, instance);
@@ -44,123 +44,123 @@ describe("can.mustache.helper.file_type", function () {
     expect(callWithInvalid).toThrow(errMsg);
   });
 
-  it("returns a default value if there is no file extension", function () {
-    instance.title = "txt";  // the filename matches a common extension
-    expect(helper(instance)).toEqual("default");
+  it('returns a default value if there is no file extension', function () {
+    instance.title = 'txt';  // the filename matches a common extension
+    expect(helper(instance)).toEqual('default');
   });
 
-  it("returns a default value for unknown file extensions", function () {
-    instance.title = "filename.foo";
-    expect(helper(instance)).toEqual("default");
+  it('returns a default value for unknown file extensions', function () {
+    instance.title = 'filename.foo';
+    expect(helper(instance)).toEqual('default');
   });
 
-  it("returns a correct value for plain text files", function () {
-    instance.title = "file.txt";
-    expect(helper(instance)).toEqual("txt");
+  it('returns a correct value for plain text files', function () {
+    instance.title = 'file.txt';
+    expect(helper(instance)).toEqual('txt');
   });
 
-  it("it is not affected by file extension's text case", function () {
-    instance.title = "file.tXT";
-    expect(helper(instance)).toEqual("txt");
+  it('it is not affected by file extension\'s text case', function () {
+    instance.title = 'file.tXT';
+    expect(helper(instance)).toEqual('txt');
   });
 
-  describe("recognizing office-like documents", function () {
-    it("returns a correct value for older Word documents", function () {
-      instance.title = "file.doc";
-      expect(helper(instance)).toEqual("doc");
+  describe('recognizing office-like documents', function () {
+    it('returns a correct value for older Word documents', function () {
+      instance.title = 'file.doc';
+      expect(helper(instance)).toEqual('doc');
     });
 
-    it("returns a correct value for newer Word documents", function () {
-      instance.title = "file.docx";
-      expect(helper(instance)).toEqual("doc");
+    it('returns a correct value for newer Word documents', function () {
+      instance.title = 'file.docx';
+      expect(helper(instance)).toEqual('doc');
     });
 
-    it("returns correct value for LibreOffice Writer documents", function () {
-      instance.title = "file.odt";
-      expect(helper(instance)).toEqual("doc");
+    it('returns correct value for LibreOffice Writer documents', function () {
+      instance.title = 'file.odt';
+      expect(helper(instance)).toEqual('doc');
     });
   });
 
-  describe("recognizing image documents", function () {
-    it("returns a correct value for JPG images", function () {
-      instance.title = "file.jpg";
-      expect(helper(instance)).toEqual("img");
+  describe('recognizing image documents', function () {
+    it('returns a correct value for JPG images', function () {
+      instance.title = 'file.jpg';
+      expect(helper(instance)).toEqual('img');
     });
 
-    it("returns a correct value for JPG images with JPEG extension",
+    it('returns a correct value for JPG images with JPEG extension',
       function () {
-        instance.title = "file.jpeg";
-        expect(helper(instance)).toEqual("img");
+        instance.title = 'file.jpeg';
+        expect(helper(instance)).toEqual('img');
       }
     );
 
-    it("returns a correct value for PNG images", function () {
-      instance.title = "file.png";
-      expect(helper(instance)).toEqual("img");
+    it('returns a correct value for PNG images', function () {
+      instance.title = 'file.png';
+      expect(helper(instance)).toEqual('img');
     });
 
-    it("returns a correct value for GIF images", function () {
-      instance.title = "file.gif";
-      expect(helper(instance)).toEqual("img");
+    it('returns a correct value for GIF images', function () {
+      instance.title = 'file.gif';
+      expect(helper(instance)).toEqual('img');
     });
 
-    it("returns a correct value for TIFF images", function () {
-      instance.title = "file.tiff";
-      expect(helper(instance)).toEqual("img");
+    it('returns a correct value for TIFF images', function () {
+      instance.title = 'file.tiff';
+      expect(helper(instance)).toEqual('img');
     });
 
-    it("returns a correct value for BMP images", function () {
-      instance.title = "file.bmp";
-      expect(helper(instance)).toEqual("img");
-    });
-  });
-
-  it("returns a correct value for PDF documents", function () {
-    instance.title = "file.pdf";
-    expect(helper(instance)).toEqual("pdf");
-  });
-
-  describe("recognizing office-like spreadsheets", function () {
-    it("returns a correct value for older Excel documents", function () {
-      instance.title = "file.xls";
-      expect(helper(instance)).toEqual("xls");
-    });
-
-    it("returns a correct value for newer Excel documents", function () {
-      instance.title = "file.xlsx";
-      expect(helper(instance)).toEqual("xls");
-    });
-
-    it("returns correct value for LibreOffice Calc documents", function () {
-      instance.title = "file.ods";
-      expect(helper(instance)).toEqual("xls");
+    it('returns a correct value for BMP images', function () {
+      instance.title = 'file.bmp';
+      expect(helper(instance)).toEqual('img');
     });
   });
 
-  describe("recognizing archive files", function () {
-    it("returns a correct value for ZIP archives", function () {
-      instance.title = "file.zip";
-      expect(helper(instance)).toEqual("zip");
+  it('returns a correct value for PDF documents', function () {
+    instance.title = 'file.pdf';
+    expect(helper(instance)).toEqual('pdf');
+  });
+
+  describe('recognizing office-like spreadsheets', function () {
+    it('returns a correct value for older Excel documents', function () {
+      instance.title = 'file.xls';
+      expect(helper(instance)).toEqual('xls');
     });
 
-    it("returns a correct value for WinRAR archives", function () {
-      instance.title = "file.rar";
-      expect(helper(instance)).toEqual("zip");
+    it('returns a correct value for newer Excel documents', function () {
+      instance.title = 'file.xlsx';
+      expect(helper(instance)).toEqual('xls');
     });
 
-    it("returns a correct value for 7-Zip archives", function () {
-      instance.title = "file.7z";
-      expect(helper(instance)).toEqual("zip");
+    it('returns correct value for LibreOffice Calc documents', function () {
+      instance.title = 'file.ods';
+      expect(helper(instance)).toEqual('xls');
+    });
+  });
+
+  describe('recognizing archive files', function () {
+    it('returns a correct value for ZIP archives', function () {
+      instance.title = 'file.zip';
+      expect(helper(instance)).toEqual('zip');
     });
 
-    it("returns a correct value for GZip archives", function () {
-      instance.title = "file.gz";
-      expect(helper(instance)).toEqual("zip");
+    it('returns a correct value for WinRAR archives', function () {
+      instance.title = 'file.rar';
+      expect(helper(instance)).toEqual('zip');
     });
 
-    it("returns a correct value for TAR archives", function () {
-      instance.title = "file.tar";
-      expect(helper(instance)).toEqual("zip");
+    it('returns a correct value for 7-Zip archives', function () {
+      instance.title = 'file.7z';
+      expect(helper(instance)).toEqual('zip');
+    });
+
+    it('returns a correct value for GZip archives', function () {
+      instance.title = 'file.gz';
+      expect(helper(instance)).toEqual('zip');
+    });
+
+    it('returns a correct value for TAR archives', function () {
+      instance.title = 'file.tar';
+      expect(helper(instance)).toEqual('zip');
     });
   });
 });

--- a/src/ggrc/assets/js_specs/mustache_helpers/get_permalink_for_object_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/get_permalink_for_object_spec.js
@@ -5,32 +5,22 @@
   Maintained By: jure@reciprocitylabs.com
 */
 
-describe("can.mustache.helper.get_permalink_for_object", function () {
-  var fakeOptions,
-      helper;
+describe('can.mustache.helper.get_permalink_for_object', function () {
+  var helper;
 
   beforeAll(function () {
-    fakeOptions = {
-      fn: jasmine.createSpy()
-    };
-
-    helper = can.Mustache._helpers["get_permalink_for_object"].fn;
+    helper = can.Mustache._helpers.get_permalink_for_object.fn;
   });
 
-  it("concatenates window.location.origin and objects view link",
-    function () {
-      var instance = {
-        viewLink: "/facility/1"
-      };
-      expect(helper(instance)).toBe(window.location.origin + "/facility/1");
-    }
-  );
+  it('concatenates window.location.origin and objects view link', function () {
+    var instance = {
+      viewLink: '/facility/1'
+    };
+    expect(helper(instance)).toBe(window.location.origin + '/facility/1');
+  });
 
-  it("returns empty string when objects view link is not present",
-    function () {
-      var instance = {};
-      expect(helper(instance)).toBe("");
-    }
-  );
-
+  it('returns empty string when objects view link is not present', function () {
+    var instance = {};
+    expect(helper(instance)).toBe('');
+  });
 });

--- a/src/ggrc/assets/js_specs/mustache_helpers/with_is_reviewer_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/with_is_reviewer_spec.js
@@ -5,55 +5,50 @@
   Maintained By: jure@reciprocitylabs.com
 */
 
-describe("can.mustache.helper.with_is_reviewer", function () {
-  var fakeOptions,
-      helper;
+describe('can.mustache.helper.with_is_reviewer', function () {
+  var fakeOptions;
+  var helper;
 
   beforeAll(function () {
     fakeOptions = {
       fn: jasmine.createSpy(),
       contexts: {
-        add: jasmine.createSpy(),
+        add: jasmine.createSpy()
       }
     };
 
-    helper = can.Mustache._helpers["with_is_reviewer"].fn;
+    helper = can.Mustache._helpers.with_is_reviewer.fn;
   });
 
-  describe("calls options.contexts.add with specified value", function() {
+  describe('calls options.contexts.add with specified value', function () {
+    it('is {is_reviewer: false} when review_task is not set', function () {
+      helper(false, fakeOptions);
+      expect(fakeOptions.contexts.add)
+        .toHaveBeenCalledWith({is_reviewer: false});
+    });
 
-    it("is {is_reviewer: false} when review_task is not set",
-      function () {
-        helper(false, fakeOptions);
-        expect(fakeOptions.contexts.add).toHaveBeenCalledWith({is_reviewer: false})
-      }
-    );
+    it('is {is_reviewer: true} when user is Admin', function () {
+      spyOn(Permission, 'is_allowed').and.returnValue(true);
+      helper({contact: {id: 12345}}, fakeOptions);
+      expect(fakeOptions.contexts.add)
+        .toHaveBeenCalledWith({is_reviewer: true});
+    });
 
-    it("is {is_reviewer: true} when user is Admin",
+    it('is {is_reviewer: false} when contact does not match current user',
       function () {
-        spyOn(Permission, "is_allowed").and.returnValue(true);
+        spyOn(Permission, 'is_allowed').and.returnValue(false);
         helper({contact: {id: 12345}}, fakeOptions);
-        expect(fakeOptions.contexts.add).toHaveBeenCalledWith({is_reviewer: true})
+        expect(fakeOptions.contexts.add)
+          .toHaveBeenCalledWith({is_reviewer: false});
       }
     );
 
-    it("is {is_reviewer: false} when contact does not match current user",
-      function () {
-        spyOn(Permission, "is_allowed").and.returnValue(false);
-        helper({contact: {id: 12345}}, fakeOptions);
-        expect(fakeOptions.contexts.add).toHaveBeenCalledWith({is_reviewer: false})
-      }
-    );
-
-    it("is {is_reviewer: true} when contact matches current user",
-      function () {
-        spyOn(Permission, "is_allowed").and.returnValue(false);
-        // GGRC.current_user.id is 1 in testing environment
-        helper({contact: {id: 1}}, fakeOptions);
-        expect(fakeOptions.contexts.add).toHaveBeenCalledWith({is_reviewer: true})
-      }
-    );
-
-  })
-
+    it('is {is_reviewer: true} when contact matches current user', function () {
+      spyOn(Permission, 'is_allowed').and.returnValue(false);
+      // GGRC.current_user.id is 1 in testing environment
+      helper({contact: {id: 1}}, fakeOptions);
+      expect(fakeOptions.contexts.add)
+        .toHaveBeenCalledWith({is_reviewer: true});
+    });
+  });
 });

--- a/src/ggrc/assets/js_specs/spec_helpers.js
+++ b/src/ggrc/assets/js_specs/spec_helpers.js
@@ -11,7 +11,7 @@
  */
 
 // polls check function and calls done when truthy
-function waitsFor(check, done) {
+function waitsFor(check, done) {  // eslint-disable-line no-unused-vars
   if (!check()) {
     setTimeout(function () {
       waitsFor(check, done);
@@ -22,11 +22,15 @@ function waitsFor(check, done) {
 }
 
 // This is primarily useful for passing as the fail case for
-//  promises, since every item passed to it will show up in 
+//  promises, since every item passed to it will show up in
 //  the jasmine output.
-window.failAll = function(done) {
-  return function() {
-    can.each(arguments, function(arg) { fail(JSON.stringify(arg)); });
-    done && done();
+window.failAll = function (done) {
+  return function () {
+    can.each(arguments, function (arg) {
+      fail(JSON.stringify(arg));
+    });
+    if (done) {
+      done();
+    }
   };
 };

--- a/src/ggrc/assets/js_specs/spec_setup.js
+++ b/src/ggrc/assets/js_specs/spec_setup.js
@@ -13,194 +13,194 @@ Spec setup file.
 window.GGRC = window.GGRC || {};
 GGRC.current_user = GGRC.current_user || {
   id: 1,
-  type: "Person"
+  type: 'Person'
 };
 GGRC.permissions = {
   create: {},
-  delete: {},
+  'delete': {},
   read: {},
   update: {},
-  view_object_page: {},
+  view_object_page: {}
 };
 GGRC.config = {};
 GGRC.Bootstrap = {
   exportable: [{
-    "title_plural": "Audits",
-    "model_singular": "Audit"
+    title_plural: 'Audits',
+    model_singular: 'Audit'
   }, {
-    "title_plural": "Clauses",
-    "model_singular": "Clause"
+    title_plural: 'Clauses',
+    model_singular: 'Clause'
   }, {
-    "title_plural": "Contracts",
-    "model_singular": "Contract"
+    title_plural: 'Contracts',
+    model_singular: 'Contract'
   }, {
-    "title_plural": "Controls",
-    "model_singular": "Control"
+    title_plural: 'Controls',
+    model_singular: 'Control'
   }, {
-    "title_plural": "Control Assessments",
-    "model_singular": "ControlAssessment"
+    title_plural: 'Control Assessments',
+    model_singular: 'ControlAssessment'
   }, {
-    "title_plural": "Cycles",
-    "model_singular": "Cycle"
+    title_plural: 'Cycles',
+    model_singular: 'Cycle'
   }, {
-    "title_plural": "Cycle Task Groups",
-    "model_singular": "CycleTaskGroup"
+    title_plural: 'Cycle Task Groups',
+    model_singular: 'CycleTaskGroup'
   }, {
-    "title_plural": "Cycle Task Group Object Tasks",
-    "model_singular": "CycleTaskGroupObjectTask"
+    title_plural: 'Cycle Task Group Object Tasks',
+    model_singular: 'CycleTaskGroupObjectTask'
   }, {
-    "title_plural": "Data Assets",
-    "model_singular": "DataAsset"
+    title_plural: 'Data Assets',
+    model_singular: 'DataAsset'
   }, {
-    "title_plural": "Facilities",
-    "model_singular": "Facility"
+    title_plural: 'Facilities',
+    model_singular: 'Facility'
   }, {
-    "title_plural": "Issues",
-    "model_singular": "Issue"
+    title_plural: 'Issues',
+    model_singular: 'Issue'
   }, {
-    "title_plural": "Markets",
-    "model_singular": "Market"
+    title_plural: 'Markets',
+    model_singular: 'Market'
   }, {
-    "title_plural": "Objectives",
-    "model_singular": "Objective"
+    title_plural: 'Objectives',
+    model_singular: 'Objective'
   }, {
-    "title_plural": "Org Groups",
-    "model_singular": "OrgGroup"
+    title_plural: 'Org Groups',
+    model_singular: 'OrgGroup'
   }, {
-    "title_plural": "People",
-    "model_singular": "Person"
+    title_plural: 'People',
+    model_singular: 'Person'
   }, {
-    "title_plural": "Policies",
-    "model_singular": "Policy"
+    title_plural: 'Policies',
+    model_singular: 'Policy'
   }, {
-    "title_plural": "Processes",
-    "model_singular": "Process"
+    title_plural: 'Processes',
+    model_singular: 'Process'
   }, {
-    "title_plural": "Products",
-    "model_singular": "Product"
+    title_plural: 'Products',
+    model_singular: 'Product'
   }, {
-    "title_plural": "Programs",
-    "model_singular": "Program"
+    title_plural: 'Programs',
+    model_singular: 'Program'
   }, {
-    "title_plural": "Projects",
-    "model_singular": "Project"
+    title_plural: 'Projects',
+    model_singular: 'Project'
   }, {
-    "title_plural": "Regulations",
-    "model_singular": "Regulation"
+    title_plural: 'Regulations',
+    model_singular: 'Regulation'
   }, {
-    "title_plural": "Requests",
-    "model_singular": "Request"
+    title_plural: 'Requests',
+    model_singular: 'Request'
   }, {
-    "title_plural": "Responses",
-    "model_singular": "Response"
+    title_plural: 'Responses',
+    model_singular: 'Response'
   }, {
-    "title_plural": "Risk Assessments",
-    "model_singular": "RiskAssessment"
+    title_plural: 'Risk Assessments',
+    model_singular: 'RiskAssessment'
   }, {
-    "title_plural": "Sections",
-    "model_singular": "Section"
+    title_plural: 'Sections',
+    model_singular: 'Section'
   }, {
-    "title_plural": "Standards",
-    "model_singular": "Standard"
+    title_plural: 'Standards',
+    model_singular: 'Standard'
   }, {
-    "title_plural": "Systems",
-    "model_singular": "System"
+    title_plural: 'Systems',
+    model_singular: 'System'
   }, {
-    "title_plural": "Task Groups",
-    "model_singular": "TaskGroup"
+    title_plural: 'Task Groups',
+    model_singular: 'TaskGroup'
   }, {
-    "title_plural": "Task Group Tasks",
-    "model_singular": "TaskGroupTask"
+    title_plural: 'Task Group Tasks',
+    model_singular: 'TaskGroupTask'
   }, {
-    "title_plural": "Vendors",
-    "model_singular": "Vendor"
+    title_plural: 'Vendors',
+    model_singular: 'Vendor'
   }, {
-    "title_plural": "Workflows",
-    "model_singular": "Workflow"
+    title_plural: 'Workflows',
+    model_singular: 'Workflow'
   }],
   importable: [{
-    "title_plural": "Audits",
-    "model_singular": "Audit"
+    title_plural: 'Audits',
+    model_singular: 'Audit'
   }, {
-    "title_plural": "Clauses",
-    "model_singular": "Clause"
+    title_plural: 'Clauses',
+    model_singular: 'Clause'
   }, {
-    "title_plural": "Contracts",
-    "model_singular": "Contract"
+    title_plural: 'Contracts',
+    model_singular: 'Contract'
   }, {
-    "title_plural": "Controls",
-    "model_singular": "Control"
+    title_plural: 'Controls',
+    model_singular: 'Control'
   }, {
-    "title_plural": "Control Assessments",
-    "model_singular": "ControlAssessment"
+    title_plural: 'Control Assessments',
+    model_singular: 'ControlAssessment'
   }, {
-    "title_plural": "Data Assets",
-    "model_singular": "DataAsset"
+    title_plural: 'Data Assets',
+    model_singular: 'DataAsset'
   }, {
-    "title_plural": "Facilities",
-    "model_singular": "Facility"
+    title_plural: 'Facilities',
+    model_singular: 'Facility'
   }, {
-    "title_plural": "Issues",
-    "model_singular": "Issue"
+    title_plural: 'Issues',
+    model_singular: 'Issue'
   }, {
-    "title_plural": "Markets",
-    "model_singular": "Market"
+    title_plural: 'Markets',
+    model_singular: 'Market'
   }, {
-    "title_plural": "Objectives",
-    "model_singular": "Objective"
+    title_plural: 'Objectives',
+    model_singular: 'Objective'
   }, {
-    "title_plural": "Org Groups",
-    "model_singular": "OrgGroup"
+    title_plural: 'Org Groups',
+    model_singular: 'OrgGroup'
   }, {
-    "title_plural": "People",
-    "model_singular": "Person"
+    title_plural: 'People',
+    model_singular: 'Person'
   }, {
-    "title_plural": "Policies",
-    "model_singular": "Policy"
+    title_plural: 'Policies',
+    model_singular: 'Policy'
   }, {
-    "title_plural": "Processes",
-    "model_singular": "Process"
+    title_plural: 'Processes',
+    model_singular: 'Process'
   }, {
-    "title_plural": "Products",
-    "model_singular": "Product"
+    title_plural: 'Products',
+    model_singular: 'Product'
   }, {
-    "title_plural": "Programs",
-    "model_singular": "Program"
+    title_plural: 'Programs',
+    model_singular: 'Program'
   }, {
-    "title_plural": "Projects",
-    "model_singular": "Project"
+    title_plural: 'Projects',
+    model_singular: 'Project'
   }, {
-    "title_plural": "Regulations",
-    "model_singular": "Regulation"
+    title_plural: 'Regulations',
+    model_singular: 'Regulation'
   }, {
-    "title_plural": "Requests",
-    "model_singular": "Request"
+    title_plural: 'Requests',
+    model_singular: 'Request'
   }, {
-    "title_plural": "Responses",
-    "model_singular": "Response"
+    title_plural: 'Responses',
+    model_singular: 'Response'
   }, {
-    "title_plural": "Risk Assessments",
-    "model_singular": "RiskAssessment"
+    title_plural: 'Risk Assessments',
+    model_singular: 'RiskAssessment'
   }, {
-    "title_plural": "Sections",
-    "model_singular": "Section"
+    title_plural: 'Sections',
+    model_singular: 'Section'
   }, {
-    "title_plural": "Standards",
-    "model_singular": "Standard"
+    title_plural: 'Standards',
+    model_singular: 'Standard'
   }, {
-    "title_plural": "Systems",
-    "model_singular": "System"
+    title_plural: 'Systems',
+    model_singular: 'System'
   }, {
-    "title_plural": "Task Groups",
-    "model_singular": "TaskGroup"
+    title_plural: 'Task Groups',
+    model_singular: 'TaskGroup'
   }, {
-    "title_plural": "Task Group Tasks",
-    "model_singular": "TaskGroupTask"
+    title_plural: 'Task Group Tasks',
+    model_singular: 'TaskGroupTask'
   }, {
-    "title_plural": "Vendors",
-    "model_singular": "Vendor"
+    title_plural: 'Vendors',
+    model_singular: 'Vendor'
   }, {
-    "title_plural": "Workflows",
-    "model_singular": "Workflow"
+    title_plural: 'Workflows',
+    model_singular: 'Workflow'
   }]
 };


### PR DESCRIPTION
This PR cleans all javascript files in the `ggrc/assets/js_specs` directory.
